### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/jacobhuemmer/dops-cli/security/code-scanning/1](https://github.com/jacobhuemmer/dops-cli/security/code-scanning/1)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions in the workflow to the minimum needed. Since this workflow only checks out code, sets up Go, and runs `make ci`, it should only need read access to repository contents. We should therefore add a `permissions` block with `contents: read`. To keep the change tightly scoped and avoid affecting other jobs in this (or other) workflows, we can add the block at the job level under `jobs.test`.

Concretely, in `.github/workflows/test.yml`, under `jobs:`, inside the `test:` job, we will insert a `permissions:` key between `test:` and `runs-on: ubuntu-latest`, with `contents: read`. No other lines, steps, or actions need to change, and no imports or new methods are required because this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
