### PR TITLE
Fix sidebar scrollbar rendering on WSL

### DIFF
--- a/internal/tui/sidebar/model.go
+++ b/internal/tui/sidebar/model.go
@@ -371,10 +371,22 @@ func (m Model) View() string {
 
 	needsScrollbar := totalLines > visibleLines
 
+	trackStyle := lipgloss.NewStyle()
+	thumbStyle := lipgloss.NewStyle()
+	if m.styles != nil {
+		bg := m.styles.BackgroundElem.GetForeground()
+		trackStyle = lipgloss.NewStyle().Background(bg)
+		thumbStyle = lipgloss.NewStyle().Background(bg).Foreground(m.styles.Primary.GetForeground())
+	}
+
 	var b strings.Builder
 	for i, line := range visible {
 		if needsScrollbar {
-			b.WriteString(line + " " + scrollbarChar(i+start, totalLines, visibleLines) + "\n")
+			if isScrollThumb(i+start, totalLines, visibleLines) {
+				b.WriteString(line + " " + thumbStyle.Render("▐") + "\n")
+			} else {
+				b.WriteString(line + " " + trackStyle.Render(" ") + "\n")
+			}
 		} else {
 			b.WriteString(line + "\n")
 		}
@@ -502,17 +514,11 @@ func (m *Model) ensureVisible() {
 	}
 }
 
-func scrollbarChar(lineIdx, total, visible int) string {
-	if total <= visible {
-		return " "
-	}
+func isScrollThumb(lineIdx, total, visible int) bool {
 	thumbSize := max(1, visible*visible/total)
 	thumbStart := lineIdx * visible / total
 	pos := lineIdx - thumbStart
-	if pos >= 0 && pos < thumbSize {
-		return "█"
-	}
-	return "░"
+	return pos >= 0 && pos < thumbSize
 }
 
 func (m Model) Selected() *domain.Runbook {

--- a/internal/tui/sidebar/search_test.go
+++ b/internal/tui/sidebar/search_test.go
@@ -135,7 +135,7 @@ func TestScrollbar_NotNeededForSmallList(t *testing.T) {
 	m.Init()
 
 	view := m.View()
-	if strings.Contains(view, "█") || strings.Contains(view, "░") {
+	if strings.Contains(view, "▐") {
 		t.Error("scrollbar should not appear when content fits")
 	}
 }


### PR DESCRIPTION
## Summary
- Sidebar scrollbar used raw `█`/`░` characters with no styling, rendering as white blocks on WSL terminals
- Now uses themed `▐` thumb and space track with `BackgroundElem`/`Primary` colors, matching the output pane's scrollbar approach

## Test plan
- [ ] Verify scrollbar renders correctly on WSL Ubuntu 24.04
- [ ] Verify scrollbar renders correctly on macOS
- [ ] `go test ./...` passes