### PR TITLE
Migrate references to rundops/dops org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: vedantmgoyal9/winget-releaser@v2
         with:
-          identifier: JacobHuemmer.dops
+          identifier: RunDops.dops
           installers-regex: '\.zip$'
           max-versions-to-keep: 5
           token: ${{ secrets.WINGET_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV PATH="/opt/dops/bin:${PATH}"
 
 # DOPS_HOME is where dops looks for config.json, catalogs/, and themes/.
 # Mount your local .dops directory here:
-#   docker run -i -v ~/.dops:/data/dops ghcr.io/jacobhuemmer/dops-cli
+#   docker run -i -v ~/.dops:/data/dops ghcr.io/rundops/dops
 ENV DOPS_HOME=/data/dops
 
 RUN mkdir -p /data/dops

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@
   <p>A browsable catalog of automation scripts that operators can select, parameterize, and execute directly from the terminal.</p>
 
   <p>
-    <a href="https://jacobhuemmer.github.io/dops-cli/">Documentation</a>
+    <a href="https://rundops.github.io/dops/">Documentation</a>
     &middot;
-    <a href="https://github.com/jacobhuemmer/dops-cli/issues">Report Bug</a>
+    <a href="https://github.com/rundops/dops/issues">Report Bug</a>
     &middot;
-    <a href="https://github.com/jacobhuemmer/dops-cli/issues">Request Feature</a>
+    <a href="https://github.com/rundops/dops/issues">Request Feature</a>
   </p>
 </div>
 
@@ -159,27 +159,27 @@ dops is built for DevOps and platform engineering teams who need a consistent, s
 ### Homebrew (recommended)
 
 ```bash
-brew tap jacobhuemmer/tap
+brew tap rundops/tap
 brew install dops
 ```
 
 ### Go
 
 ```bash
-go install github.com/jacobhuemmer/dops-cli@latest
+go install github.com/rundops/dops@latest
 ```
 
 ### Docker (MCP server)
 
 ```bash
-docker run -i -v ~/.dops:/data/dops ghcr.io/jacobhuemmer/dops-cli:latest
+docker run -i -v ~/.dops:/data/dops ghcr.io/rundops/dops:latest
 ```
 
 ### From source
 
 ```bash
-git clone https://github.com/jacobhuemmer/dops-cli.git
-cd dops-cli
+git clone https://github.com/rundops/dops.git
+cd dops
 make build
 ./bin/dops
 ```
@@ -249,7 +249,7 @@ parameters:
     scope: global
 ```
 
-See the [runbook guide](https://jacobhuemmer.github.io/dops-cli/guides/runbooks) for the full YAML schema, parameter types, and shell scripting conventions.
+See the [runbook guide](https://rundops.github.io/dops/guides/runbooks) for the full YAML schema, parameter types, and shell scripting conventions.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -274,7 +274,7 @@ dops config set theme=dracula
 
 Set `theme=rainbow` for a random theme on every launch.
 
-Custom themes go in `~/.dops/themes/<name>.json`. See the [configuration reference](https://jacobhuemmer.github.io/dops-cli/reference/configuration) for the theme schema.
+Custom themes go in `~/.dops/themes/<name>.json`. See the [configuration reference](https://rundops.github.io/dops/reference/configuration) for the theme schema.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -298,7 +298,7 @@ The web UI provides:
 - Real-time execution log streaming with ANSI color support
 - Full theme support — mirrors your configured dops theme
 
-The SPA is embedded in the Go binary — no Node.js required at runtime. See the [Web UI guide](https://jacobhuemmer.github.io/dops-cli/guides/web-ui) for details.
+The SPA is embedded in the Go binary — no Node.js required at runtime. See the [Web UI guide](https://rundops.github.io/dops/guides/web-ui) for details.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -328,13 +328,13 @@ Add to `.claude/settings.json`:
 
 ```bash
 # stdio transport
-docker run -i -v ~/.dops:/data/dops ghcr.io/jacobhuemmer/dops-cli:latest
+docker run -i -v ~/.dops:/data/dops ghcr.io/rundops/dops:latest
 
 # HTTP transport
-docker run -p 8080:8080 -v ~/.dops:/data/dops ghcr.io/jacobhuemmer/dops-cli:latest --transport http --port 8080
+docker run -p 8080:8080 -v ~/.dops:/data/dops ghcr.io/rundops/dops:latest --transport http --port 8080
 ```
 
-See the [MCP guide](https://jacobhuemmer.github.io/dops-cli/guides/mcp) for details on risk controls, resources, and streaming.
+See the [MCP guide](https://rundops.github.io/dops/guides/mcp) for details on risk controls, resources, and streaming.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -355,7 +355,7 @@ See the [MCP guide](https://jacobhuemmer.github.io/dops-cli/guides/mcp) for deta
 | `ctrl+shift+p` | Command palette |
 | `q` | Quit |
 
-See the full [keyboard reference](https://jacobhuemmer.github.io/dops-cli/reference/keyboard-shortcuts) for output pane controls, search navigation, and wizard shortcuts.
+See the full [keyboard reference](https://rundops.github.io/dops/reference/keyboard-shortcuts) for output pane controls, search navigation, and wizard shortcuts.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -404,9 +404,9 @@ make ci           # Run CI checks (vet + test + build)
 <!-- GETTING HELP -->
 ## Getting Help
 
-- [Documentation](https://jacobhuemmer.github.io/dops-cli/) — guides, reference, and configuration
-- [GitHub Issues](https://github.com/jacobhuemmer/dops-cli/issues) — bug reports and feature requests
-- [CLI Reference](https://jacobhuemmer.github.io/dops-cli/reference/cli) — all commands and flags
+- [Documentation](https://rundops.github.io/dops/) — guides, reference, and configuration
+- [GitHub Issues](https://github.com/rundops/dops/issues) — bug reports and feature requests
+- [CLI Reference](https://rundops.github.io/dops/reference/cli) — all commands and flags
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -435,13 +435,13 @@ Distributed under the MIT License. See `LICENSE` for more information.
 
 
 <!-- MARKDOWN LINKS & IMAGES -->
-[release-shield]: https://img.shields.io/github/v/release/jacobhuemmer/dops-cli?style=for-the-badge
-[release-url]: https://github.com/jacobhuemmer/dops-cli/releases
-[go-shield]: https://img.shields.io/github/go-mod/go-version/jacobhuemmer/dops-cli?style=for-the-badge
+[release-shield]: https://img.shields.io/github/v/release/rundops/dops?style=for-the-badge
+[release-url]: https://github.com/rundops/dops/releases
+[go-shield]: https://img.shields.io/github/go-mod/go-version/rundops/dops?style=for-the-badge
 [go-url]: https://go.dev/
-[license-shield]: https://img.shields.io/github/license/jacobhuemmer/dops-cli?style=for-the-badge
-[license-url]: https://github.com/jacobhuemmer/dops-cli/blob/main/LICENSE
-[tests-shield]: https://img.shields.io/github/actions/workflow/status/jacobhuemmer/dops-cli/test.yml?style=for-the-badge&label=tests
-[tests-url]: https://github.com/jacobhuemmer/dops-cli/actions/workflows/test.yml
-[security-shield]: https://img.shields.io/github/actions/workflow/status/jacobhuemmer/dops-cli/security.yml?style=for-the-badge&label=security
-[security-url]: https://github.com/jacobhuemmer/dops-cli/actions/workflows/security.yml
+[license-shield]: https://img.shields.io/github/license/rundops/dops?style=for-the-badge
+[license-url]: https://github.com/rundops/dops/blob/main/LICENSE
+[tests-shield]: https://img.shields.io/github/actions/workflow/status/rundops/dops/test.yml?style=for-the-badge&label=tests
+[tests-url]: https://github.com/rundops/dops/actions/workflows/test.yml
+[security-shield]: https://img.shields.io/github/actions/workflow/status/rundops/dops/security.yml?style=for-the-badge&label=security
+[security-url]: https://github.com/rundops/dops/actions/workflows/security.yml

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from "vitepress";
 export default defineConfig({
   title: "dops",
   description: "a runbook toolkit for operators and AI agents",
-  base: "/dops-cli/",
+  base: "/dops/",
 
   head: [
-    ["link", { rel: "icon", type: "image/png", href: "/dops-cli/logo.png" }],
+    ["link", { rel: "icon", type: "image/png", href: "/dops/logo.png" }],
   ],
 
   appearance: "dark",
@@ -27,7 +27,7 @@ export default defineConfig({
       },
       {
         text: "GitHub",
-        link: "https://github.com/jacobhuemmer/dops-cli",
+        link: "https://github.com/rundops/dops",
       },
     ],
 
@@ -73,20 +73,20 @@ export default defineConfig({
     socialLinks: [
       {
         icon: "github",
-        link: "https://github.com/jacobhuemmer/dops-cli",
+        link: "https://github.com/rundops/dops",
       },
     ],
 
     footer: {
       message:
-        'Released under the <a href="https://github.com/jacobhuemmer/dops-cli/blob/main/LICENSE">MIT License</a>.',
+        'Released under the <a href="https://github.com/rundops/dops/blob/main/LICENSE">MIT License</a>.',
       copyright:
-        'Copyright © 2025 <a href="https://github.com/jacobhuemmer">Jacob Huemmer</a>',
+        'Copyright © 2025 Mason Huemmer',
     },
 
     editLink: {
       pattern:
-        "https://github.com/jacobhuemmer/dops-cli/edit/main/docs/:path",
+        "https://github.com/rundops/dops/edit/main/docs/:path",
       text: "Edit this page on GitHub",
     },
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -9,26 +9,26 @@ title: Getting Started
 ### Homebrew (macOS/Linux)
 
 ```sh
-brew install jacobhuemmer/tap/dops
+brew install rundops/tap/dops
 ```
 
 ### Go
 
 ```sh
-go install github.com/jacobhuemmer/dops-cli@latest
+go install github.com/rundops/dops@latest
 ```
 
 ### Docker
 
 ```sh
-docker pull ghcr.io/jacobhuemmer/dops-cli:latest
+docker pull ghcr.io/rundops/dops:latest
 ```
 
 ### From Source
 
 ```sh
-git clone https://github.com/jacobhuemmer/dops-cli.git
-cd dops-cli
+git clone https://github.com/rundops/dops.git
+cd dops
 make install
 ```
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -34,7 +34,7 @@ Run the MCP server in a container:
 ```sh
 docker run -i --rm \
   -v ~/.dops:/data/dops \
-  ghcr.io/jacobhuemmer/dops-cli:latest
+  ghcr.io/rundops/dops:latest
 ```
 
 The container uses `DOPS_HOME=/data/dops` and runs `dops mcp serve --transport stdio` by default.
@@ -45,7 +45,7 @@ For HTTP transport:
 docker run -d --rm \
   -v ~/.dops:/data/dops \
   -p 8080:8080 \
-  ghcr.io/jacobhuemmer/dops-cli:latest \
+  ghcr.io/rundops/dops:latest \
   dops mcp serve --transport http --port 8080
 ```
 

--- a/docs/guides/verification.md
+++ b/docs/guides/verification.md
@@ -36,7 +36,7 @@ Each GitHub Release includes:
 cosign verify-blob \
   --certificate checksums.txt.pem \
   --signature checksums.txt.sig \
-  --certificate-identity-regexp "https://github.com/jacobhuemmer/dops-cli" \
+  --certificate-identity-regexp "https://github.com/rundops/dops" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   checksums.txt
 ```
@@ -64,9 +64,9 @@ if ($expected -eq $actual) { "OK" } else { "MISMATCH" }
 
 ```sh
 cosign verify \
-  --certificate-identity-regexp "https://github.com/jacobhuemmer/dops-cli" \
+  --certificate-identity-regexp "https://github.com/rundops/dops" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  ghcr.io/jacobhuemmer/dops-cli:v0.1.0
+  ghcr.io/rundops/dops:v0.1.0
 ```
 
 Replace `v0.1.0` with the version you pulled.

--- a/docs/guides/web-ui.md
+++ b/docs/guides/web-ui.md
@@ -6,7 +6,7 @@ title: Web UI
 
 dops includes a browser-based interface that mirrors the TUI experience. Launch it with `dops open`.
 
-<img src="https://raw.githubusercontent.com/jacobhuemmer/dops-cli/main/assets/web-demo.gif" alt="dops web UI demo" width="900" />
+<img src="https://raw.githubusercontent.com/rundops/dops/main/assets/web-demo.gif" alt="dops web UI demo" width="900" />
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ hero:
       link: /guides/getting-started
     - theme: alt
       text: View on GitHub
-      link: https://github.com/jacobhuemmer/dops-cli
+      link: https://github.com/rundops/dops
 
 features:
   - icon: "🖥️"
@@ -108,7 +108,7 @@ features:
 <div class="demo-section">
   <h2>Terminal UI</h2>
   <p>Navigate catalogs, fill parameters, confirm risk, and watch live output — all from the terminal.</p>
-  <img src="https://raw.githubusercontent.com/jacobhuemmer/dops-cli/main/assets/demo.gif" alt="dops TUI demo" />
+  <img src="https://raw.githubusercontent.com/rundops/dops/main/assets/demo.gif" alt="dops TUI demo" />
 </div>
 
 <div class="demo-divider"></div>
@@ -116,7 +116,7 @@ features:
 <div class="demo-section">
   <h2>Web UI</h2>
   <p>The same experience in the browser. Launch with <code>dops open</code>.</p>
-  <img src="https://raw.githubusercontent.com/jacobhuemmer/dops-cli/main/assets/web-demo.gif" alt="dops web UI demo" />
+  <img src="https://raw.githubusercontent.com/rundops/dops/main/assets/web-demo.gif" alt="dops web UI demo" />
 </div>
 
 <div class="demo-divider"></div>
@@ -124,35 +124,35 @@ features:
 <div class="commands-section">
   <h2>Commands</h2>
   <div class="commands-grid">
-    <a class="cmd-card" href="/dops-cli/reference/cli/dops">
+    <a class="cmd-card" href="/dops/reference/cli/dops">
       <code>dops</code>
       <span>Launch the interactive TUI</span>
     </a>
-    <a class="cmd-card" href="/dops-cli/reference/cli/dops-run">
+    <a class="cmd-card" href="/dops/reference/cli/dops-run">
       <code>dops run</code>
       <span>Execute a runbook non-interactively</span>
     </a>
-    <a class="cmd-card" href="/dops-cli/reference/cli/dops-open">
+    <a class="cmd-card" href="/dops/reference/cli/dops-open">
       <code>dops open</code>
       <span>Launch the web UI in a browser</span>
     </a>
-    <a class="cmd-card" href="/dops-cli/reference/cli/dops-init">
+    <a class="cmd-card" href="/dops/reference/cli/dops-init">
       <code>dops init</code>
       <span>Initialize configuration</span>
     </a>
-    <a class="cmd-card" href="/dops-cli/reference/cli/dops-catalog">
+    <a class="cmd-card" href="/dops/reference/cli/dops-catalog">
       <code>dops catalog</code>
       <span>Manage runbook catalogs</span>
     </a>
-    <a class="cmd-card" href="/dops-cli/reference/cli/dops-config">
+    <a class="cmd-card" href="/dops/reference/cli/dops-config">
       <code>dops config</code>
       <span>Read and write configuration</span>
     </a>
-    <a class="cmd-card" href="/dops-cli/reference/cli/dops-mcp">
+    <a class="cmd-card" href="/dops/reference/cli/dops-mcp">
       <code>dops mcp</code>
       <span>MCP server for AI agents</span>
     </a>
-    <a class="cmd-card" href="/dops-cli/reference/cli/dops-completion">
+    <a class="cmd-card" href="/dops/reference/cli/dops-completion">
       <code>dops completion</code>
       <span>Generate shell completions</span>
     </a>

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// githubRepo is the owner/repo for the GitHub Releases API.
-	githubRepo = "jacobhuemmer/dops-cli"
+	githubRepo = "rundops/dops"
 
 	// cacheTTL controls how often we re-check for updates.
 	cacheTTL = 1 * time.Hour

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -60,7 +60,7 @@ function riskDotClass(level: string): string {
       </button>
       <div class="flex items-center gap-2.5">
         <a
-          href="https://jacobhuemmer.github.io/dops-cli/"
+          href="https://rundops.github.io/dops/"
           target="_blank"
           rel="noopener noreferrer"
           class="text-fg-subtle hover:text-fg-muted transition-colors duration-150"
@@ -69,7 +69,7 @@ function riskDotClass(level: string): string {
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M0 1.75A.75.75 0 01.75 1h4.253c1.227 0 2.317.59 3 1.501A3.744 3.744 0 0111.006 1h4.245a.75.75 0 01.75.75v10.5a.75.75 0 01-.75.75h-4.507a2.25 2.25 0 00-1.591.659l-.622.621a.75.75 0 01-1.06 0l-.623-.621A2.25 2.25 0 005.258 13H.75a.75.75 0 01-.75-.75zm7.251 10.324l.004-5.073-.002-2.253A2.25 2.25 0 005.003 2.5H1.5v9h3.757a3.75 3.75 0 011.994.574zM8.755 4.75l-.004 7.322a3.752 3.752 0 011.992-.572H14.5v-9h-3.495a2.25 2.25 0 00-2.25 2.25z"/></svg>
         </a>
         <a
-          href="https://github.com/jacobhuemmer/dops-cli"
+          href="https://github.com/rundops/dops"
           target="_blank"
           rel="noopener noreferrer"
           class="text-fg-subtle hover:text-fg-muted transition-colors duration-150"


### PR DESCRIPTION
## Summary
- Update all repository URLs from `jacobhuemmer/dops-cli` to `rundops/dops`
- Update Homebrew tap from `jacobhuemmer/tap` to `rundops/tap`
- Update winget identifier from `JacobHuemmer.dops` to `RunDops.dops`
- Update VitePress base path from `/dops-cli/` to `/dops/`
- Update copyright to Mason Huemmer

## Test plan
- [ ] Verify all links in README resolve correctly
- [ ] Verify docs build with `npm run docs:build`
- [ ] Verify `go build ./...` succeeds