### PR TITLE
Fix docs branding: larger logos, favicon, broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@
 
 <!-- PROJECT LOGO -->
 <div align="center">
-  <img src="assets/logos/logo-2048.png" alt="dops logo" width="400" />
-
+  <img src="assets/logos/logo-2048.png" alt="dops logo" width="600" />
   <h3>the do(ops) cli</h3>
 
   <p>A browsable catalog of automation scripts that operators can select, parameterize, and execute directly from the terminal.</p>

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
 
   head: [
     ["link", { rel: "icon", type: "image/png", href: "/logo.png" }],
+    ["link", { rel: "apple-touch-icon", href: "/logo.png" }],
   ],
 
   appearance: "dark",

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,10 @@ features:
 ---
 
 <style>
+.VPHero .VPImage {
+  max-width: 320px !important;
+  max-height: 320px !important;
+}
 .demo-section {
   max-width: 960px;
   margin: 0 auto;
@@ -124,35 +128,35 @@ features:
 <div class="commands-section">
   <h2>Commands</h2>
   <div class="commands-grid">
-    <a class="cmd-card" href="/dops/reference/cli/dops">
+    <a class="cmd-card" href="/reference/cli/dops">
       <code>dops</code>
       <span>Launch the interactive TUI</span>
     </a>
-    <a class="cmd-card" href="/dops/reference/cli/dops-run">
+    <a class="cmd-card" href="/reference/cli/dops-run">
       <code>dops run</code>
       <span>Execute a runbook non-interactively</span>
     </a>
-    <a class="cmd-card" href="/dops/reference/cli/dops-open">
+    <a class="cmd-card" href="/reference/cli/dops-open">
       <code>dops open</code>
       <span>Launch the web UI in a browser</span>
     </a>
-    <a class="cmd-card" href="/dops/reference/cli/dops-init">
+    <a class="cmd-card" href="/reference/cli/dops-init">
       <code>dops init</code>
       <span>Initialize configuration</span>
     </a>
-    <a class="cmd-card" href="/dops/reference/cli/dops-catalog">
+    <a class="cmd-card" href="/reference/cli/dops-catalog">
       <code>dops catalog</code>
       <span>Manage runbook catalogs</span>
     </a>
-    <a class="cmd-card" href="/dops/reference/cli/dops-config">
+    <a class="cmd-card" href="/reference/cli/dops-config">
       <code>dops config</code>
       <span>Read and write configuration</span>
     </a>
-    <a class="cmd-card" href="/dops/reference/cli/dops-mcp">
+    <a class="cmd-card" href="/reference/cli/dops-mcp">
       <code>dops mcp</code>
       <span>MCP server for AI agents</span>
     </a>
-    <a class="cmd-card" href="/dops/reference/cli/dops-completion">
+    <a class="cmd-card" href="/reference/cli/dops-completion">
       <code>dops completion</code>
       <span>Generate shell completions</span>
     </a>


### PR DESCRIPTION
## Summary
- Increase README logo from 400px to 600px and tighten spacing
- Enlarge docs hero image to 320px (was ~180px default)
- Add apple-touch-icon for browser tabs
- Fix 8 command card links on homepage still using old `/dops/` base path

## Test plan
- [ ] Verify README logo size on GitHub
- [ ] Verify rundops.dev hero image is larger
- [ ] Verify browser tab shows dops logo
- [ ] Verify all command card links work on rundops.dev