### PR TITLE
Fix dirty git state in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 22
 
       - name: Build web UI
-        run: make web
+        run: make web && git checkout -- internal/web/dist/.gitkeep
 
       - uses: sigstore/cosign-installer@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ internal/web/dist/
 # Node
 web/node_modules/
 web/dist/
+web/tsconfig.tsbuildinfo
 tapes/node_modules/
 tapes/web-demo-results/
 docs/node_modules/

--- a/web/tsconfig.tsbuildinfo
+++ b/web/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/main.ts","./src/vite-env.d.ts","./src/lib/api.ts","./src/lib/toast.ts","./src/lib/types.ts","./src/app.vue","./src/components/errorboundary.vue","./src/components/sidebar.vue","./src/components/toastcontainer.vue","./src/views/dashboard.vue","./src/views/executionview.vue","./src/views/runbookdetail.vue"],"version":"5.7.3"}


### PR DESCRIPTION
## Summary
- Gitignore `web/tsconfig.tsbuildinfo` (TypeScript build cache modified by `make web`)
- Restore `internal/web/dist/.gitkeep` after `make web` so goreleaser sees a clean tree
- Untrack `tsconfig.tsbuildinfo` from git

Fixes the `git is in a dirty state` error from goreleaser after the `make web` step was added.