### PR TITLE
Remove duplicate GitHub link from docs nav bar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -27,10 +27,6 @@ export default defineConfig({
           { text: "Keyboard Shortcuts", link: "/reference/keyboard-shortcuts" },
         ],
       },
-      {
-        text: "GitHub",
-        link: "https://github.com/rundops/dops",
-      },
     ],
 
     sidebar: {


### PR DESCRIPTION
## Summary
- Remove the text "GitHub" link from the nav bar since the GitHub icon in `socialLinks` already provides the same link

## Test plan
- [ ] Verify only one GitHub link appears in the nav (the icon)