### PR TITLE
Add live demo playground on Fly.io

### DIFF
--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -1,0 +1,54 @@
+# Demo playground: serves the dops web UI with sample runbooks.
+
+# Stage 1: Build web UI
+FROM node:22-alpine AS web
+WORKDIR /app/web
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+COPY web/ ./
+RUN npm run build
+
+# Stage 2: Build Go binary
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=web /app/internal/web/dist/ ./internal/web/dist/
+RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o /dops .
+
+# Stage 3: Runtime
+FROM alpine:3.20
+
+RUN apk add --no-cache git bash
+
+COPY --from=builder /dops /opt/dops/bin/dops
+ENV PATH="/opt/dops/bin:${PATH}"
+
+# Set up demo environment.
+ENV DOPS_HOME=/data/dops
+RUN mkdir -p /data/dops/catalogs
+
+# Copy sample catalogs into the container.
+COPY catalogs/ /data/dops/catalogs/demo/
+
+# Write a config that points to the demo catalog.
+RUN cat > /data/dops/config.json <<'EOF'
+{
+  "theme": "github",
+  "defaults": { "max_risk_level": "critical" },
+  "catalogs": [
+    {
+      "name": "demo",
+      "display_name": "Demo",
+      "path": "/data/dops/catalogs/demo",
+      "active": true,
+      "policy": { "max_risk_level": "critical" }
+    }
+  ]
+}
+EOF
+
+EXPOSE 3000
+
+ENTRYPOINT ["dops", "open", "--no-browser", "--port", "3000"]

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     siteTitle: "dops",
 
     nav: [
+      { text: "Demo", link: "/demo" },
       { text: "Guides", link: "/guides/getting-started" },
       {
         text: "Reference",

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,36 @@
+---
+layout: page
+title: Demo
+---
+
+<style>
+.demo-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+.demo-container h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: var(--vp-c-text-1);
+}
+.demo-container p {
+  color: var(--vp-c-text-2);
+  margin-bottom: 1.25rem;
+  font-size: 0.95rem;
+}
+.demo-frame {
+  width: 100%;
+  height: 80vh;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 12px;
+  background: var(--vp-c-bg-alt);
+}
+</style>
+
+<div class="demo-container">
+  <h1>Try dops</h1>
+  <p>Browse runbooks, fill parameters, and run scripts — all in the browser. This is a live sandbox with sample runbooks.</p>
+  <iframe class="demo-frame" src="https://dops-demo.fly.dev" allow="clipboard-write" loading="lazy"></iframe>
+</div>

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,16 @@
+app = "dops-demo"
+primary_region = "ord"
+
+[build]
+  dockerfile = "Dockerfile.demo"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"


### PR DESCRIPTION
## Summary
- Add `Dockerfile.demo` that packages the web UI with all sample catalogs and serves via `dops open`
- Add `fly.toml` for Fly.io deployment (auto-stop/start, shared CPU, 256MB — costs nothing when idle)
- Add `/demo` page to docs site that iframes the live Fly.io instance
- Add "Demo" link to docs nav bar

## Deploy steps
1. `fly auth login`
2. `fly apps create dops-demo`
3. `fly deploy`

## Test plan
- [ ] `docker build -f Dockerfile.demo -t dops-demo .` builds successfully
- [ ] `docker run -p 3000:3000 dops-demo` serves the web UI with sample runbooks
- [ ] `cd docs && npx vitepress dev` shows Demo link in nav and iframe loads at /demo