### PR TITLE
Fix Fly app name and demo custom domain

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -32,5 +32,5 @@ title: Demo
 <div class="demo-container">
   <h1>Try dops</h1>
   <p>Browse runbooks, fill parameters, and run scripts — all in the browser. This is a live sandbox with sample runbooks.</p>
-  <iframe class="demo-frame" src="https://dops-demo.fly.dev" allow="clipboard-write" loading="lazy"></iframe>
+  <iframe class="demo-frame" src="https://demo.rundops.dev" allow="clipboard-write" loading="lazy"></iframe>
 </div>

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-app = "dops-demo"
+app = "dops"
 primary_region = "ord"
 
 [build]


### PR DESCRIPTION
## Summary
- Update `fly.toml` app name from `dops-demo` to `dops` (matching the actual Fly app)
- Update demo iframe URL to `https://demo.rundops.dev`

## Test plan
- [ ] `fly status -a dops` confirms app exists
- [ ] `fly certs show demo.rundops.dev -a dops` shows cert provisioned
- [ ] Demo page loads at rundops.dev/demo