### PR TITLE
Add live demo links to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
   <p>A browsable catalog of automation scripts that operators can select, parameterize, and execute directly from the terminal.</p>
 
   <p>
+    <a href="https://demo.rundops.dev"><strong>Try the Live Demo</strong></a>
+    &middot;
     <a href="https://rundops.dev/">Documentation</a>
     &middot;
     <a href="https://github.com/rundops/dops/issues">Report Bug</a>

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -7,18 +7,23 @@ title: Demo
 .demo-container {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 1rem;
+  padding: 1.5rem 1rem;
 }
-.demo-container h1 {
+.demo-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+.demo-header h1 {
   font-size: 1.75rem;
   font-weight: 700;
   margin-bottom: 0.5rem;
   color: var(--vp-c-text-1);
 }
-.demo-container p {
+.demo-header p {
   color: var(--vp-c-text-2);
-  margin-bottom: 1.25rem;
   font-size: 0.95rem;
+  max-width: 600px;
+  margin: 0 auto;
 }
 .demo-frame {
   width: 100%;
@@ -27,10 +32,31 @@ title: Demo
   border-radius: 12px;
   background: var(--vp-c-bg-alt);
 }
+.demo-hint {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin-top: 1.25rem;
+  flex-wrap: wrap;
+}
+.demo-hint span {
+  color: var(--vp-c-text-3);
+  font-size: 0.85rem;
+}
+.demo-hint code {
+  font-size: 0.8rem;
+  color: var(--vp-c-brand-1);
+}
 </style>
 
 <div class="demo-container">
-  <h1>Try dops</h1>
-  <p>Browse runbooks, fill parameters, and run scripts — all in the browser. This is a live sandbox with sample runbooks.</p>
+  <div class="demo-header">
+    <h1>Try dops</h1>
+    <p>A live sandbox with sample runbooks. Browse catalogs, fill parameters, and execute scripts — no install required.</p>
+  </div>
   <iframe class="demo-frame" src="https://demo.rundops.dev" allow="clipboard-write" loading="lazy"></iframe>
+  <div class="demo-hint">
+    <span>Install locally: <code>brew tap rundops/tap && brew install dops</code></span>
+    <span>Or run: <code>dops open</code></span>
+  </div>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,9 @@ hero:
   tagline: A browsable catalog of automation scripts that operators can select, parameterize, and execute directly from the terminal — or in the browser.
   actions:
     - theme: brand
+      text: Try Live Demo
+      link: https://demo.rundops.dev
+    - theme: alt
       text: Get Started
       link: /guides/getting-started
     - theme: alt
@@ -100,6 +103,38 @@ features:
   font-size: 0.85rem;
   color: var(--vp-c-text-2);
 }
+.try-cta {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+.try-cta h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: var(--vp-c-text-1);
+}
+.try-cta p {
+  color: var(--vp-c-text-2);
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+}
+.try-btn {
+  display: inline-block;
+  padding: 0.75rem 2rem;
+  background: var(--vp-c-brand-1);
+  color: var(--vp-c-bg) !important;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: opacity 0.2s, transform 0.2s;
+}
+.try-btn:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
 </style>
 
 <div class="demo-section">
@@ -122,6 +157,14 @@ features:
   <h2>MCP Server</h2>
   <p>Expose runbooks as tools for AI agents. Run with <code>dops mcp serve</code>.</p>
   <img src="https://raw.githubusercontent.com/rundops/dops/main/assets/mcp-demo.gif" alt="dops MCP demo" />
+</div>
+
+<div class="demo-divider"></div>
+
+<div class="try-cta">
+  <h2>See it for yourself</h2>
+  <p>No install needed. Browse runbooks, fill parameters, and run scripts in a live sandbox.</p>
+  <a class="try-btn" href="https://demo.rundops.dev">Try the Live Demo &rarr;</a>
 </div>
 
 <div class="demo-divider"></div>


### PR DESCRIPTION
## Summary
- **README**: "Try the Live Demo" added as the first link in the header, pointing to demo.rundops.dev
- **Docs hero**: "Try Live Demo" is now the primary (brand) action button, with Get Started and GitHub as secondary
- **Docs homepage**: new CTA banner section between MCP demo and commands grid — centered heading, description, and styled button
- **Demo page**: polished layout with centered header, descriptive copy, and install hints below the iframe

## Test plan
- [ ] README renders correctly on GitHub with the new link
- [ ] `cd docs && npx vitepress dev` — hero shows 3 buttons with Demo as primary
- [ ] CTA banner appears between MCP section and commands grid
- [ ] Demo page shows centered header and install hints below iframe
- [ ] All links point to https://demo.rundops.dev