### PR TITLE
Fix panic when all wizard parameters have saved values

### DIFF
--- a/internal/tui/wizard/model.go
+++ b/internal/tui/wizard/model.go
@@ -595,7 +595,7 @@ func (m Model) FooterHints() string {
 }
 
 func (m Model) View() string {
-	if len(m.params) == 0 {
+	if len(m.params) == 0 || m.current >= len(m.params) {
 		return ""
 	}
 

--- a/internal/tui/wizard/model_test.go
+++ b/internal/tui/wizard/model_test.go
@@ -221,6 +221,12 @@ func TestSkipSavedFields_AllPrefilled(t *testing.T) {
 	if cmd == nil {
 		t.Error("Init should return a submit command when all fields are skipped")
 	}
+
+	// View must not panic when current is past all params.
+	view := m.View()
+	if view != "" {
+		t.Errorf("View should return empty when all fields completed, got %q", view)
+	}
 }
 
 func TestSkipSavedFields_PromptAll(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes index out of range panic in `wizard.Model.View()` when all runbook parameters have pre-filled values from the vault
- When all params are skippable, `New()` sets `m.current = len(m.params)` to signal completion. `View()` was then called by BubbleTea (before the `SubmitMsg` command was processed) and panicked indexing `m.params[m.current]`
- Adds bounds guard: `m.current >= len(m.params)` returns empty string
- Adds regression test in `TestSkipSavedFields_AllPrefilled` that calls `View()` after all-skip initialization

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/tui/wizard/...` passes
- [x] Regression test reproduces the panic without the fix
- [ ] Manual: launch dops with all runbook params saved, execute runbook — no panic