### PR TITLE
Add test coverage (80%) and Gremlins mutation testing

### DIFF
--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -1,0 +1,28 @@
+unleash:
+  diff: ""
+  workers: 0
+  exclude-files:
+    - ".*_generated\\.go$"
+    - "internal/executor/demo_data\\.go$"
+    - "\\.claude/worktrees/.*"
+  threshold:
+    efficacy: 70
+    mutant-coverage: 65
+
+mutants:
+  arithmetic-base:
+    enabled: true
+  conditionals-boundary:
+    enabled: true
+  conditionals-negation:
+    enabled: true
+  increment-decrement:
+    enabled: true
+  invert-negatives:
+    enabled: true
+  invert-logical:
+    enabled: false
+  invert-loopctrl:
+    enabled: false
+  invert-assignments:
+    enabled: false

--- a/cmd/catalog_test.go
+++ b/cmd/catalog_test.go
@@ -1,0 +1,644 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"dops/internal/domain"
+)
+
+func TestIsValidGitRef(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"main", true},
+		{"v1.0.0", true},
+		{"feature/branch-name", true},
+		{"abc123", true},
+		{"release-1.2.3", true},
+		{"refs/tags/v1", true},
+		{"my_branch", true},
+		{"", false},
+		{"ref with spaces", false},
+		{"ref;injection", false},
+		{"ref&cmd", false},
+		{"ref|pipe", false},
+		{"ref$(cmd)", false},
+		{"ref`cmd`", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			got := isValidGitRef(tt.ref)
+			if got != tt.want {
+				t.Errorf("isValidGitRef(%q) = %v, want %v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateSubPath(t *testing.T) {
+	t.Run("valid subdir", func(t *testing.T) {
+		root := t.TempDir()
+		sub := filepath.Join(root, "runbooks")
+		os.MkdirAll(sub, 0o755)
+
+		got, err := validateSubPath(root, "runbooks")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "runbooks" {
+			t.Errorf("got %q, want %q", got, "runbooks")
+		}
+	})
+
+	t.Run("nested subdir", func(t *testing.T) {
+		root := t.TempDir()
+		sub := filepath.Join(root, "a", "b")
+		os.MkdirAll(sub, 0o755)
+
+		got, err := validateSubPath(root, "a/b")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != filepath.Clean("a/b") {
+			t.Errorf("got %q, want %q", got, filepath.Clean("a/b"))
+		}
+	})
+
+	t.Run("absolute path rejected", func(t *testing.T) {
+		root := t.TempDir()
+		_, err := validateSubPath(root, "/etc/passwd")
+		if err == nil {
+			t.Fatal("expected error for absolute path")
+		}
+		if !strings.Contains(err.Error(), "relative path") {
+			t.Errorf("error %q should mention relative path", err.Error())
+		}
+	})
+
+	t.Run("parent traversal rejected", func(t *testing.T) {
+		root := t.TempDir()
+		_, err := validateSubPath(root, "../escape")
+		if err == nil {
+			t.Fatal("expected error for parent traversal")
+		}
+	})
+
+	t.Run("nonexistent subdir rejected", func(t *testing.T) {
+		root := t.TempDir()
+		_, err := validateSubPath(root, "noexist")
+		if err == nil {
+			t.Fatal("expected error for nonexistent subdir")
+		}
+		if !strings.Contains(err.Error(), "does not exist") {
+			t.Errorf("error %q should mention does not exist", err.Error())
+		}
+	})
+
+	t.Run("file not directory rejected", func(t *testing.T) {
+		root := t.TempDir()
+		os.WriteFile(filepath.Join(root, "afile"), []byte("x"), 0o644)
+
+		_, err := validateSubPath(root, "afile")
+		if err == nil {
+			t.Fatal("expected error for file (not directory)")
+		}
+		if !strings.Contains(err.Error(), "not a directory") {
+			t.Errorf("error %q should mention not a directory", err.Error())
+		}
+	})
+}
+
+// initDopsDir creates a minimal dopsDir with config for testing catalog commands.
+func initDopsDir(t *testing.T, catalogs ...domain.Catalog) string {
+	t.Helper()
+	dir := t.TempDir()
+	dopsDir := filepath.Join(dir, ".dops")
+	os.MkdirAll(dopsDir, 0o755)
+
+	cfg := &domain.Config{
+		Theme:    "tokyonight",
+		Defaults: domain.Defaults{MaxRiskLevel: domain.RiskMedium},
+		Catalogs: catalogs,
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	os.WriteFile(filepath.Join(dopsDir, "config.json"), data, 0o644)
+
+	return dopsDir
+}
+
+func readCatalogConfig(t *testing.T, dopsDir string) *domain.Config {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dopsDir, "config.json"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg domain.Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	return &cfg
+}
+
+func TestCatalogList(t *testing.T) {
+	t.Run("empty catalog list", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		_, err := executeCmd([]string{"catalog", "list"}, dopsDir)
+		if err != nil {
+			t.Fatalf("catalog list: %v", err)
+		}
+	})
+
+	t.Run("lists existing catalogs", func(t *testing.T) {
+		dopsDir := initDopsDir(t, domain.Catalog{
+			Name:   "mycat",
+			Path:   "/some/path",
+			Active: true,
+		})
+		_, err := executeCmd([]string{"catalog", "list"}, dopsDir)
+		if err != nil {
+			t.Fatalf("catalog list: %v", err)
+		}
+	})
+}
+
+func TestCatalogAdd(t *testing.T) {
+	t.Run("add local directory", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+
+		// Create a directory to add as catalog.
+		catalogDir := t.TempDir()
+
+		_, err := executeCmd([]string{"catalog", "add", catalogDir}, dopsDir)
+		if err != nil {
+			t.Fatalf("catalog add: %v", err)
+		}
+
+		cfg := readCatalogConfig(t, dopsDir)
+		if len(cfg.Catalogs) != 1 {
+			t.Fatalf("catalogs = %d, want 1", len(cfg.Catalogs))
+		}
+		if !cfg.Catalogs[0].Active {
+			t.Error("catalog should be active")
+		}
+	})
+
+	t.Run("add nonexistent path", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		_, err := executeCmd([]string{"catalog", "add", "/nonexistent/path/xyz"}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for nonexistent path")
+		}
+		if !strings.Contains(err.Error(), "path does not exist") {
+			t.Errorf("error %q should mention path does not exist", err.Error())
+		}
+	})
+
+	t.Run("add file instead of directory", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		f := filepath.Join(t.TempDir(), "afile")
+		os.WriteFile(f, []byte("x"), 0o644)
+
+		_, err := executeCmd([]string{"catalog", "add", f}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for file path")
+		}
+		if !strings.Contains(err.Error(), "not a directory") {
+			t.Errorf("error %q should mention not a directory", err.Error())
+		}
+	})
+
+	t.Run("duplicate catalog name rejected", func(t *testing.T) {
+		catalogDir := t.TempDir()
+		name := filepath.Base(catalogDir)
+
+		dopsDir := initDopsDir(t, domain.Catalog{
+			Name:   name,
+			Path:   "/original/path",
+			Active: true,
+		})
+
+		_, err := executeCmd([]string{"catalog", "add", catalogDir}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for duplicate catalog")
+		}
+		if !strings.Contains(err.Error(), "already exists") {
+			t.Errorf("error %q should mention already exists", err.Error())
+		}
+	})
+
+	t.Run("add with display name", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		catalogDir := t.TempDir()
+
+		_, err := executeCmd([]string{"catalog", "add", "--display-name", "My Catalog", catalogDir}, dopsDir)
+		if err != nil {
+			t.Fatalf("catalog add: %v", err)
+		}
+
+		cfg := readCatalogConfig(t, dopsDir)
+		if cfg.Catalogs[0].DisplayName != "My Catalog" {
+			t.Errorf("display name = %q, want %q", cfg.Catalogs[0].DisplayName, "My Catalog")
+		}
+	})
+
+	t.Run("add with invalid display name", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		catalogDir := t.TempDir()
+
+		longName := strings.Repeat("a", 51)
+		_, err := executeCmd([]string{"catalog", "add", "--display-name", longName, catalogDir}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for display name too long")
+		}
+	})
+
+	t.Run("requires exactly one arg", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		_, err := executeCmd([]string{"catalog", "add"}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for missing arg")
+		}
+	})
+}
+
+func TestCatalogRemove(t *testing.T) {
+	t.Run("remove existing catalog", func(t *testing.T) {
+		dopsDir := initDopsDir(t, domain.Catalog{
+			Name:   "mycat",
+			Path:   "/some/path",
+			Active: true,
+		})
+
+		_, err := executeCmd([]string{"catalog", "remove", "mycat"}, dopsDir)
+		if err != nil {
+			t.Fatalf("catalog remove: %v", err)
+		}
+
+		cfg := readCatalogConfig(t, dopsDir)
+		if len(cfg.Catalogs) != 0 {
+			t.Errorf("catalogs = %d, want 0", len(cfg.Catalogs))
+		}
+	})
+
+	t.Run("remove nonexistent catalog", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		_, err := executeCmd([]string{"catalog", "remove", "nonexistent"}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for nonexistent catalog")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("error %q should mention not found", err.Error())
+		}
+	})
+
+	t.Run("remove only the named catalog", func(t *testing.T) {
+		dopsDir := initDopsDir(t,
+			domain.Catalog{Name: "keep", Path: "/keep", Active: true},
+			domain.Catalog{Name: "drop", Path: "/drop", Active: true},
+		)
+
+		_, err := executeCmd([]string{"catalog", "remove", "drop"}, dopsDir)
+		if err != nil {
+			t.Fatalf("catalog remove: %v", err)
+		}
+
+		cfg := readCatalogConfig(t, dopsDir)
+		if len(cfg.Catalogs) != 1 {
+			t.Fatalf("catalogs = %d, want 1", len(cfg.Catalogs))
+		}
+		if cfg.Catalogs[0].Name != "keep" {
+			t.Errorf("remaining catalog = %q, want keep", cfg.Catalogs[0].Name)
+		}
+	})
+
+	t.Run("requires exactly one arg", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		_, err := executeCmd([]string{"catalog", "remove"}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for missing arg")
+		}
+	})
+}
+
+func TestCatalogInstall_FlagValidation(t *testing.T) {
+	t.Run("invalid risk level rejected early", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		_, err := executeCmd([]string{
+			"catalog", "install",
+			"--risk", "yolo",
+			"https://example.com/org/repo.git",
+		}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for invalid risk level")
+		}
+		if !strings.Contains(err.Error(), "invalid risk level") {
+			t.Errorf("error %q should mention invalid risk level", err.Error())
+		}
+	})
+
+	t.Run("invalid display name rejected early", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		longName := strings.Repeat("x", 51)
+		_, err := executeCmd([]string{
+			"catalog", "install",
+			"--display-name", longName,
+			"https://example.com/org/repo.git",
+		}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for invalid display name")
+		}
+	})
+
+	t.Run("existing directory rejected", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		catalogsDir := filepath.Join(dopsDir, "catalogs")
+		os.MkdirAll(filepath.Join(catalogsDir, "repo"), 0o755)
+
+		_, err := executeCmd([]string{
+			"catalog", "install",
+			"https://example.com/org/repo.git",
+		}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for existing directory")
+		}
+		if !strings.Contains(err.Error(), "already exists") {
+			t.Errorf("error %q should mention already exists", err.Error())
+		}
+	})
+
+	t.Run("requires exactly one arg", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		_, err := executeCmd([]string{"catalog", "install"}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for missing arg")
+		}
+	})
+}
+
+func TestCatalogUpdate_Validation(t *testing.T) {
+	t.Run("nonexistent catalog rejected", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		_, err := executeCmd([]string{"catalog", "update", "nonexistent"}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for nonexistent catalog")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("error %q should mention not found", err.Error())
+		}
+	})
+
+	t.Run("local-only catalog cannot update without display-name", func(t *testing.T) {
+		dopsDir := initDopsDir(t, domain.Catalog{
+			Name:   "local",
+			Path:   "/some/path",
+			Active: true,
+			// No URL — local only.
+		})
+
+		_, err := executeCmd([]string{"catalog", "update", "local"}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for local-only catalog")
+		}
+		if !strings.Contains(err.Error(), "local-only") {
+			t.Errorf("error %q should mention local-only", err.Error())
+		}
+	})
+
+	t.Run("invalid risk level rejected", func(t *testing.T) {
+		// Need a catalog with URL and a real path for EvalSymlinks.
+		catPath := t.TempDir()
+		dopsDir := initDopsDir(t, domain.Catalog{
+			Name:   "mycat",
+			Path:   catPath,
+			URL:    "https://example.com/org/repo.git",
+			Active: true,
+		})
+
+		_, err := executeCmd([]string{
+			"catalog", "update",
+			"--risk", "invalid",
+			"--display-name", "skip-git", // set display-name to avoid git pull
+			"mycat",
+		}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for invalid risk level")
+		}
+		if !strings.Contains(err.Error(), "invalid risk level") {
+			t.Errorf("error %q should mention invalid risk level", err.Error())
+		}
+	})
+
+	t.Run("display-name only update on local catalog succeeds", func(t *testing.T) {
+		dopsDir := initDopsDir(t, domain.Catalog{
+			Name:   "local",
+			Path:   "/some/path",
+			Active: true,
+		})
+
+		_, err := executeCmd([]string{
+			"catalog", "update",
+			"--display-name", "New Name",
+			"local",
+		}, dopsDir)
+		if err != nil {
+			t.Fatalf("update display-name: %v", err)
+		}
+
+		cfg := readCatalogConfig(t, dopsDir)
+		if cfg.Catalogs[0].DisplayName != "New Name" {
+			t.Errorf("display name = %q, want %q", cfg.Catalogs[0].DisplayName, "New Name")
+		}
+	})
+
+	t.Run("clear display-name", func(t *testing.T) {
+		dopsDir := initDopsDir(t, domain.Catalog{
+			Name:        "local",
+			DisplayName: "Old Name",
+			Path:        "/some/path",
+			Active:      true,
+		})
+
+		_, err := executeCmd([]string{
+			"catalog", "update",
+			"--display-name", "",
+			"local",
+		}, dopsDir)
+		if err != nil {
+			t.Fatalf("update display-name: %v", err)
+		}
+
+		cfg := readCatalogConfig(t, dopsDir)
+		if cfg.Catalogs[0].DisplayName != "" {
+			t.Errorf("display name = %q, want empty", cfg.Catalogs[0].DisplayName)
+		}
+	})
+
+	t.Run("invalid ref rejected", func(t *testing.T) {
+		catPath := t.TempDir()
+		dopsDir := initDopsDir(t, domain.Catalog{
+			Name:   "mycat",
+			Path:   catPath,
+			URL:    "https://example.com/org/repo.git",
+			Active: true,
+		})
+
+		_, err := executeCmd([]string{
+			"catalog", "update",
+			"--ref", "ref with spaces",
+			"--display-name", "skip", // set to avoid default git pull path
+			"mycat",
+		}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for invalid ref")
+		}
+		if !strings.Contains(err.Error(), "invalid git ref") {
+			t.Errorf("error %q should mention invalid git ref", err.Error())
+		}
+	})
+
+	t.Run("requires exactly one arg", func(t *testing.T) {
+		dopsDir := initDopsDir(t)
+		_, err := executeCmd([]string{"catalog", "update"}, dopsDir)
+		if err == nil {
+			t.Fatal("expected error for missing arg")
+		}
+	})
+}
+
+func TestCatalogCmd_SubcommandWiring(t *testing.T) {
+	cmd := newCatalogCmd("/tmp/fake")
+	subNames := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+
+	expected := []string{"list", "add", "remove", "install", "update"}
+	for _, name := range expected {
+		if !subNames[name] {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+}
+
+func TestRegisterCatalog(t *testing.T) {
+	dopsDir := initDopsDir(t)
+	cat := domain.Catalog{Name: "new-cat", Path: "/some/path", Active: true}
+
+	if err := registerCatalog(dopsDir, cat); err != nil {
+		t.Fatalf("registerCatalog: %v", err)
+	}
+
+	cfg := readCatalogConfig(t, dopsDir)
+	if len(cfg.Catalogs) != 1 {
+		t.Fatalf("catalogs = %d, want 1", len(cfg.Catalogs))
+	}
+	if cfg.Catalogs[0].Name != "new-cat" {
+		t.Errorf("name = %q, want new-cat", cfg.Catalogs[0].Name)
+	}
+}
+
+func TestRegisterCatalog_AppendsToPrevious(t *testing.T) {
+	dopsDir := initDopsDir(t, domain.Catalog{Name: "existing", Path: "/old", Active: true})
+	cat := domain.Catalog{Name: "new", Path: "/new", Active: true}
+
+	if err := registerCatalog(dopsDir, cat); err != nil {
+		t.Fatalf("registerCatalog: %v", err)
+	}
+
+	cfg := readCatalogConfig(t, dopsDir)
+	if len(cfg.Catalogs) != 2 {
+		t.Fatalf("catalogs = %d, want 2", len(cfg.Catalogs))
+	}
+}
+
+func TestCloneRepo_ExistingDir(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "existing")
+	os.MkdirAll(target, 0o755)
+
+	err := cloneRepo("https://example.com/repo.git", target, "")
+	if err == nil {
+		t.Fatal("expected error for existing directory")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error %q should mention already exists", err.Error())
+	}
+}
+
+func TestVersionCmd(t *testing.T) {
+	dopsDir := initDopsDir(t)
+	out, err := executeCmd([]string{"version"}, dopsDir)
+	if err != nil {
+		t.Fatalf("version: %v", err)
+	}
+	if !strings.Contains(out, "version") {
+		t.Errorf("output %q should contain 'version'", out)
+	}
+}
+
+func TestCheckmark(t *testing.T) {
+	if checkmark(true) != "\u2713" {
+		t.Error("checkmark(true) should be ✓")
+	}
+	if checkmark(false) != "\u2717" {
+		t.Error("checkmark(false) should be ✗")
+	}
+}
+
+func TestLoadSaveConfig_RoundTrip(t *testing.T) {
+	dopsDir := initDopsDir(t, domain.Catalog{Name: "test", Path: "/test", Active: true})
+
+	cfg, err := loadConfig(dopsDir)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if len(cfg.Catalogs) != 1 {
+		t.Fatalf("catalogs = %d, want 1", len(cfg.Catalogs))
+	}
+
+	cfg.Catalogs = append(cfg.Catalogs, domain.Catalog{Name: "new", Path: "/new", Active: true})
+	if err := saveConfig(dopsDir, cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	cfg2, err := loadConfig(dopsDir)
+	if err != nil {
+		t.Fatalf("loadConfig after save: %v", err)
+	}
+	if len(cfg2.Catalogs) != 2 {
+		t.Fatalf("catalogs = %d, want 2", len(cfg2.Catalogs))
+	}
+}
+
+func TestMCPCmd_SubcommandWiring(t *testing.T) {
+	cmd := newMCPCmd("/tmp/fake")
+	subNames := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+	if !subNames["serve"] {
+		t.Error("missing serve subcommand")
+	}
+	if !subNames["tools"] {
+		t.Error("missing tools subcommand")
+	}
+}
+
+func TestCloneRepo_InvalidRef(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "newrepo")
+
+	err := cloneRepo("https://example.com/repo.git", target, "ref with spaces")
+	if err == nil {
+		t.Fatal("expected error for invalid ref")
+	}
+	if !strings.Contains(err.Error(), "invalid git ref") {
+		t.Errorf("error %q should mention invalid git ref", err.Error())
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,252 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dops/internal/domain"
+	"dops/internal/vault"
+)
+
+func TestSplitError(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantTitle  string
+		wantDetail string
+	}{
+		{
+			name:       "error with colon",
+			err:        errors.New("config: file not found"),
+			wantTitle:  "Config",
+			wantDetail: "file not found",
+		},
+		{
+			name:       "error without colon",
+			err:        errors.New("something went wrong"),
+			wantTitle:  "something went wrong",
+			wantDetail: "",
+		},
+		{
+			name:       "empty error",
+			err:        errors.New(""),
+			wantTitle:  "",
+			wantDetail: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			title, detail := splitError(tt.err)
+			if title != tt.wantTitle {
+				t.Errorf("title = %q, want %q", title, tt.wantTitle)
+			}
+			if detail != tt.wantDetail {
+				t.Errorf("detail = %q, want %q", detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestTitleCase(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "normal string", in: "hello", want: "Hello"},
+		{name: "empty string", in: "", want: ""},
+		{name: "single char", in: "a", want: "A"},
+		{name: "already capitalized", in: "Hello", want: "Hello"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := titleCase(tt.in)
+			if got != tt.want {
+				t.Errorf("titleCase(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// stubVault implements domain.VaultStore for testing migrateVarsToVault.
+type stubVault struct {
+	exists bool
+	saved  *domain.Vars
+}
+
+func (v *stubVault) Load() (*domain.Vars, error) { return v.saved, nil }
+func (v *stubVault) Save(vars *domain.Vars) error { v.saved = vars; return nil }
+func (v *stubVault) Exists() bool                 { return v.exists }
+
+// stubFS implements config.FileSystem for testing migrateVarsToVault.
+type stubFS struct {
+	files map[string][]byte
+}
+
+func (f *stubFS) ReadFile(path string) ([]byte, error) {
+	data, ok := f.files[path]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return data, nil
+}
+
+func (f *stubFS) WriteFile(path string, data []byte, perm fs.FileMode) error {
+	f.files[path] = data
+	return nil
+}
+
+func (f *stubFS) MkdirAll(path string, perm fs.FileMode) error {
+	return nil
+}
+
+func TestMigrateVarsToVault(t *testing.T) {
+	configWithVars := func() []byte {
+		data, _ := json.Marshal(map[string]any{
+			"theme": "tokyonight",
+			"vars": map[string]any{
+				"global":  map[string]any{"region": "us-east-1"},
+				"catalog": map[string]any{},
+			},
+		})
+		return data
+	}
+
+	configWithoutVars := func() []byte {
+		data, _ := json.Marshal(map[string]any{
+			"theme": "tokyonight",
+		})
+		return data
+	}
+
+	configWithEmptyVars := func() []byte {
+		data, _ := json.Marshal(map[string]any{
+			"theme": "tokyonight",
+			"vars": map[string]any{
+				"global":  map[string]any{},
+				"catalog": map[string]any{},
+			},
+		})
+		return data
+	}
+
+	tests := []struct {
+		name       string
+		vlt        *stubVault
+		fs         *stubFS
+		configPath string
+		wantSaved  bool // whether vars should be saved to vault
+	}{
+		{
+			name:       "vault already exists",
+			vlt:        &stubVault{exists: true},
+			fs:         &stubFS{files: map[string][]byte{}},
+			configPath: "/fake/config.json",
+			wantSaved:  false,
+		},
+		{
+			name:       "no config file",
+			vlt:        &stubVault{exists: false},
+			fs:         &stubFS{files: map[string][]byte{}},
+			configPath: "/fake/config.json",
+			wantSaved:  false,
+		},
+		{
+			name:       "config with vars",
+			vlt:        &stubVault{exists: false},
+			fs:         &stubFS{files: map[string][]byte{"/fake/config.json": configWithVars()}},
+			configPath: "/fake/config.json",
+			wantSaved:  true,
+		},
+		{
+			name:       "config without vars",
+			vlt:        &stubVault{exists: false},
+			fs:         &stubFS{files: map[string][]byte{"/fake/config.json": configWithoutVars()}},
+			configPath: "/fake/config.json",
+			wantSaved:  false,
+		},
+		{
+			name:       "empty vars",
+			vlt:        &stubVault{exists: false},
+			fs:         &stubFS{files: map[string][]byte{"/fake/config.json": configWithEmptyVars()}},
+			configPath: "/fake/config.json",
+			wantSaved:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := migrateVarsToVault(tt.configPath, tt.vlt, tt.fs)
+			if err != nil {
+				t.Fatalf("migrateVarsToVault() error = %v", err)
+			}
+			if tt.wantSaved && tt.vlt.saved == nil {
+				t.Error("expected vars to be saved to vault, but nothing was saved")
+			}
+			if !tt.wantSaved && tt.vlt.saved != nil {
+				t.Error("expected no save to vault, but vars were saved")
+			}
+		})
+	}
+}
+
+// TestMigrateVarsToVault_CleanedConfig verifies that the vars key is removed
+// from config.json after migration using real vault encryption.
+func TestMigrateVarsToVault_CleanedConfig(t *testing.T) {
+	dir := t.TempDir()
+	dopsDir := filepath.Join(dir, ".dops")
+	os.MkdirAll(filepath.Join(dopsDir, "keys"), 0o700)
+
+	configPath := filepath.Join(dopsDir, "config.json")
+	configData, _ := json.MarshalIndent(map[string]any{
+		"theme": "tokyonight",
+		"vars": map[string]any{
+			"global":  map[string]any{"region": "us-east-1"},
+			"catalog": map[string]any{},
+		},
+	}, "", "  ")
+	os.WriteFile(configPath, configData, 0o644)
+
+	vaultPath := filepath.Join(dopsDir, "vault.json")
+	keysDir := filepath.Join(dopsDir, "keys")
+	vlt := vault.New(vaultPath, keysDir)
+
+	// Use real OS filesystem.
+	realFS := &osFS{}
+	err := migrateVarsToVault(configPath, vlt, realFS)
+	if err != nil {
+		t.Fatalf("migrateVarsToVault() error = %v", err)
+	}
+
+	// Verify vault was created with vars.
+	vars, err := vlt.Load()
+	if err != nil {
+		t.Fatalf("load vault: %v", err)
+	}
+	if vars.Global["region"] != "us-east-1" {
+		t.Errorf("vault region = %v, want us-east-1", vars.Global["region"])
+	}
+
+	// Verify config.json no longer has vars key.
+	cleaned, _ := os.ReadFile(configPath)
+	var raw map[string]json.RawMessage
+	json.Unmarshal(cleaned, &raw)
+	if _, ok := raw["vars"]; ok {
+		t.Error("config.json should not contain vars after migration")
+	}
+}
+
+// osFS implements config.FileSystem using the real OS filesystem.
+type osFS struct{}
+
+func (f *osFS) ReadFile(path string) ([]byte, error)              { return os.ReadFile(path) }
+func (f *osFS) WriteFile(path string, data []byte, perm fs.FileMode) error {
+	return os.WriteFile(path, data, perm)
+}
+func (f *osFS) MkdirAll(path string, perm fs.FileMode) error { return os.MkdirAll(path, perm) }

--- a/internal/adapters/fs_test.go
+++ b/internal/adapters/fs_test.go
@@ -71,3 +71,79 @@ func TestExpandHome(t *testing.T) {
 		})
 	}
 }
+
+func TestOSFileSystem_ReadWriteFile(t *testing.T) {
+	fs := NewOSFileSystem()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+
+	if err := fs.WriteFile(path, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("got %q, want hello", data)
+	}
+}
+
+func TestOSFileSystem_ReadDir(t *testing.T) {
+	fs := NewOSFileSystem()
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0o644)
+	os.WriteFile(filepath.Join(dir, "b.txt"), []byte("b"), 0o644)
+
+	entries, err := fs.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("entries = %d, want 2", len(entries))
+	}
+}
+
+func TestOSFileSystem_MkdirAll(t *testing.T) {
+	fs := NewOSFileSystem()
+	dir := filepath.Join(t.TempDir(), "a", "b", "c")
+
+	if err := fs.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("should be a directory")
+	}
+}
+
+func TestOSFileSystem_Stat(t *testing.T) {
+	fs := NewOSFileSystem()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	os.WriteFile(path, []byte("x"), 0o644)
+
+	info, err := fs.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.IsDir() {
+		t.Error("should not be a directory")
+	}
+
+	_, err = fs.Stat(filepath.Join(dir, "nonexistent"))
+	if err == nil {
+		t.Error("Stat nonexistent should error")
+	}
+}
+
+func TestOSFileSystem_ReadFile_Error(t *testing.T) {
+	fs := NewOSFileSystem()
+	_, err := fs.ReadFile("/nonexistent/path/xyz")
+	if err == nil {
+		t.Error("ReadFile nonexistent should error")
+	}
+}

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -1,0 +1,259 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "test",
+		Short: "A test command",
+		Long:  "A longer description of the test command",
+	}
+}
+
+func TestHelpFunc(t *testing.T) {
+	cmd := newTestCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	HelpFunc(cmd, nil)
+
+	out := buf.String()
+	if !strings.Contains(out, "test") {
+		t.Error("output should contain command name")
+	}
+	if !strings.Contains(out, "A longer description") {
+		t.Error("output should contain long description")
+	}
+}
+
+func TestRenderHelpHeader_Root(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "dops",
+		Short: "DevOps toolkit",
+	}
+
+	out := renderHelpHeader(cmd)
+
+	if !strings.Contains(out, "do(ops) cli") {
+		t.Error("root header should contain 'do(ops) cli'")
+	}
+	if !strings.Contains(out, "DevOps toolkit") {
+		t.Error("root header should contain short description")
+	}
+}
+
+func TestRenderHelpHeader_Root_LongDesc(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:  "dops",
+		Long: "A longer root description",
+	}
+
+	out := renderHelpHeader(cmd)
+
+	if !strings.Contains(out, "A longer root description") {
+		t.Error("root header should prefer Long over Short")
+	}
+}
+
+func TestRenderHelpHeader_Root_NoDesc(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "dops",
+	}
+
+	out := renderHelpHeader(cmd)
+
+	if !strings.Contains(out, "do(ops) cli") {
+		t.Error("root header should contain 'do(ops) cli' even without description")
+	}
+}
+
+func TestRenderHelpHeader_Subcommand(t *testing.T) {
+	root := &cobra.Command{Use: "dops"}
+	child := &cobra.Command{
+		Use:   "run",
+		Short: "Run a task",
+		Long:  "Run a task with full options",
+	}
+	root.AddCommand(child)
+
+	out := renderHelpHeader(child)
+
+	if !strings.Contains(out, "dops run") {
+		t.Error("subcommand header should contain command path")
+	}
+	if !strings.Contains(out, "Run a task with full options") {
+		t.Error("subcommand header should prefer Long description")
+	}
+}
+
+func TestRenderHelpHeader_Subcommand_ShortOnly(t *testing.T) {
+	root := &cobra.Command{Use: "dops"}
+	child := &cobra.Command{
+		Use:   "run",
+		Short: "Run a task",
+	}
+	root.AddCommand(child)
+
+	out := renderHelpHeader(child)
+
+	if !strings.Contains(out, "Run a task") {
+		t.Error("subcommand header should fall back to Short description")
+	}
+}
+
+func TestRenderHelpHeader_Subcommand_NoDesc(t *testing.T) {
+	root := &cobra.Command{Use: "dops"}
+	child := &cobra.Command{Use: "run"}
+	root.AddCommand(child)
+
+	out := renderHelpHeader(child)
+
+	if !strings.Contains(out, "dops run") {
+		t.Error("subcommand header should contain command path")
+	}
+}
+
+func TestRenderHelpUsage_Basic(t *testing.T) {
+	cmd := newTestCmd()
+
+	out := renderHelpUsage(cmd)
+
+	if !strings.Contains(out, "USAGE") {
+		t.Error("output should contain USAGE section")
+	}
+	if !strings.Contains(out, "test") {
+		t.Error("output should contain usage line with command name")
+	}
+}
+
+func TestRenderHelpUsage_WithSubcommands(t *testing.T) {
+	root := &cobra.Command{Use: "dops"}
+	child := &cobra.Command{
+		Use:   "run",
+		Short: "Run a task",
+		RunE:  func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(child)
+
+	out := renderHelpUsage(root)
+
+	if !strings.Contains(out, "COMMANDS") {
+		t.Error("output should contain COMMANDS section when subcommands exist")
+	}
+	if !strings.Contains(out, "run") {
+		t.Error("output should list subcommand name")
+	}
+	if !strings.Contains(out, "Run a task") {
+		t.Error("output should list subcommand description")
+	}
+	if !strings.Contains(out, "[command]") {
+		t.Error("usage line should show [command] placeholder")
+	}
+	if !strings.Contains(out, "--help") {
+		t.Error("output should contain help footer")
+	}
+}
+
+func TestRenderHelpUsage_WithExamples(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:     "test",
+		Short:   "A test",
+		Example: "test --verbose\ntest --dry-run",
+	}
+
+	out := renderHelpUsage(cmd)
+
+	if !strings.Contains(out, "test --verbose") {
+		t.Error("output should contain first example line")
+	}
+	if !strings.Contains(out, "test --dry-run") {
+		t.Error("output should contain second example line")
+	}
+}
+
+func TestRenderHelpUsage_WithFlags(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "A test",
+	}
+	cmd.Flags().BoolP("verbose", "v", false, "Enable verbose output")
+	cmd.Flags().String("output", "json", "Output format")
+
+	out := renderHelpUsage(cmd)
+
+	if !strings.Contains(out, "FLAGS") {
+		t.Error("output should contain FLAGS section")
+	}
+	if !strings.Contains(out, "--verbose") {
+		t.Error("output should contain --verbose flag")
+	}
+	if !strings.Contains(out, "-v") {
+		t.Error("output should contain -v shorthand")
+	}
+	if !strings.Contains(out, "--output") {
+		t.Error("output should contain --output flag")
+	}
+	if !strings.Contains(out, "json") {
+		t.Error("output should contain default value for output flag")
+	}
+}
+
+func TestRenderHelpUsage_WithInheritedFlags(t *testing.T) {
+	root := &cobra.Command{Use: "dops"}
+	root.PersistentFlags().Bool("debug", false, "Enable debug mode")
+	child := &cobra.Command{
+		Use:   "run",
+		Short: "Run a task",
+	}
+	root.AddCommand(child)
+
+	out := renderHelpUsage(child)
+
+	if !strings.Contains(out, "GLOBAL FLAGS") {
+		t.Error("output should contain GLOBAL FLAGS section")
+	}
+	if !strings.Contains(out, "--debug") {
+		t.Error("output should contain inherited --debug flag")
+	}
+}
+
+func TestRenderFlag_Hidden(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool("secret", false, "Hidden flag")
+	_ = cmd.Flags().MarkHidden("secret")
+
+	out := renderHelpUsage(cmd)
+
+	if strings.Contains(out, "secret") {
+		t.Error("output should not contain hidden flags")
+	}
+}
+
+func TestRenderCommands_SkipsHiddenAndDeprecated(t *testing.T) {
+	root := &cobra.Command{Use: "dops"}
+	noop := func(cmd *cobra.Command, args []string) error { return nil }
+	visible := &cobra.Command{Use: "run", Short: "Run a task", RunE: noop}
+	hidden := &cobra.Command{Use: "internal", Short: "Hidden", Hidden: true, RunE: noop}
+	deprecated := &cobra.Command{Use: "old", Short: "Old", Deprecated: "use run", RunE: noop}
+	root.AddCommand(visible, hidden, deprecated)
+
+	var buf bytes.Buffer
+	renderCommands(&buf, root)
+	out := buf.String()
+
+	if !strings.Contains(out, "run") {
+		t.Error("output should contain visible command")
+	}
+	if strings.Contains(out, "internal") {
+		t.Error("output should not contain hidden command")
+	}
+	if strings.Contains(out, "old") {
+		t.Error("output should not contain deprecated command")
+	}
+}

--- a/internal/config/path_extra_test.go
+++ b/internal/config/path_extra_test.go
@@ -1,0 +1,456 @@
+package config
+
+import (
+	"dops/internal/domain"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"testing"
+)
+
+// --- Tests for setDefaults (0% covered) ---
+
+func TestSetDefaults_MaxRiskLevel_Valid(t *testing.T) {
+	levels := []string{"low", "medium", "high", "critical"}
+	for _, level := range levels {
+		t.Run(level, func(t *testing.T) {
+			cfg := &domain.Config{}
+			err := Set(cfg, "defaults.max_risk_level", level)
+			if err != nil {
+				t.Fatalf("Set defaults.max_risk_level=%q: %v", level, err)
+			}
+			if string(cfg.Defaults.MaxRiskLevel) != level {
+				t.Errorf("MaxRiskLevel = %q, want %q", cfg.Defaults.MaxRiskLevel, level)
+			}
+		})
+	}
+}
+
+func TestSetDefaults_MaxRiskLevel_InvalidString(t *testing.T) {
+	cfg := &domain.Config{}
+	err := Set(cfg, "defaults.max_risk_level", "unknown-level")
+	if err == nil {
+		t.Error("expected error for invalid risk level")
+	}
+}
+
+func TestSetDefaults_MaxRiskLevel_NonString(t *testing.T) {
+	cfg := &domain.Config{}
+	err := Set(cfg, "defaults.max_risk_level", 42)
+	if err == nil {
+		t.Error("expected error when value is not a string")
+	}
+}
+
+func TestSetDefaults_IncompletePath(t *testing.T) {
+	cfg := &domain.Config{}
+	err := Set(cfg, "defaults", "value")
+	if err == nil {
+		t.Error("expected error for incomplete defaults path")
+	}
+}
+
+func TestSetDefaults_UnknownKey(t *testing.T) {
+	cfg := &domain.Config{}
+	err := Set(cfg, "defaults.nonexistent", "value")
+	if err == nil {
+		t.Error("expected error for unknown defaults key")
+	}
+}
+
+// --- Tests for uncovered Get branches ---
+
+func TestGet_ThemeNestedPath(t *testing.T) {
+	cfg := newTestConfig()
+	_, err := Get(cfg, "theme.nested")
+	if err == nil {
+		t.Error("expected error for nested theme path")
+	}
+}
+
+func TestGet_DefaultsIncompletePath(t *testing.T) {
+	cfg := newTestConfig()
+	_, err := Get(cfg, "defaults")
+	if err == nil {
+		t.Error("expected error for incomplete defaults path")
+	}
+}
+
+func TestGet_DefaultsUnknownKey(t *testing.T) {
+	cfg := newTestConfig()
+	_, err := Get(cfg, "defaults.nonexistent")
+	if err == nil {
+		t.Error("expected error for unknown defaults key")
+	}
+}
+
+func TestGet_VarsIncompletePath(t *testing.T) {
+	cfg := newTestConfig()
+	_, err := Get(cfg, "vars")
+	if err == nil {
+		t.Error("expected error for incomplete vars path")
+	}
+}
+
+func TestGet_VarsUnknownScope(t *testing.T) {
+	cfg := newTestConfig()
+	_, err := Get(cfg, "vars.unknown.key")
+	if err == nil {
+		t.Error("expected error for unknown vars scope")
+	}
+}
+
+func TestGet_CatalogVarsIncompletePath(t *testing.T) {
+	cfg := newTestConfig()
+	_, err := Get(cfg, "vars.catalog")
+	if err == nil {
+		t.Error("expected error for incomplete catalog vars path")
+	}
+}
+
+func TestGet_RunbookVarsIncompletePath(t *testing.T) {
+	cfg := newTestConfig()
+	_, err := Get(cfg, "vars.catalog.default.runbooks")
+	if err == nil {
+		t.Error("expected error for incomplete runbook vars path")
+	}
+}
+
+func TestGet_RunbookVarsMissingRunbook(t *testing.T) {
+	cfg := newTestConfig()
+	_, err := Get(cfg, "vars.catalog.default.runbooks.missing.key")
+	if err == nil {
+		t.Error("expected error for missing runbook")
+	}
+}
+
+func TestGet_RunbookVarsMissingKey(t *testing.T) {
+	cfg := newTestConfig()
+	_, err := Get(cfg, "vars.catalog.default.runbooks.hello-world.missing")
+	if err == nil {
+		t.Error("expected error for missing runbook var key")
+	}
+}
+
+func TestGet_CatalogVarMissingKey(t *testing.T) {
+	cfg := newTestConfig()
+	_, err := Get(cfg, "vars.catalog.default.missing_key")
+	if err == nil {
+		t.Error("expected error for missing catalog var key")
+	}
+}
+
+func TestGet_GlobalVarsNilMap(t *testing.T) {
+	cfg := &domain.Config{
+		Vars: domain.Vars{Global: nil},
+	}
+	_, err := Get(cfg, "vars.global.any")
+	if err == nil {
+		t.Error("expected error when global vars map is nil")
+	}
+}
+
+// --- Tests for Set uncovered branches ---
+
+func TestSet_ThemeWithSpaces(t *testing.T) {
+	cfg := &domain.Config{}
+	err := Set(cfg, "theme", "has space")
+	if err == nil {
+		t.Error("expected error for theme with spaces")
+	}
+}
+
+func TestSet_ThemeWithTab(t *testing.T) {
+	cfg := &domain.Config{}
+	err := Set(cfg, "theme", "has\ttab")
+	if err == nil {
+		t.Error("expected error for theme with tab")
+	}
+}
+
+func TestSet_ThemeNonString(t *testing.T) {
+	cfg := &domain.Config{}
+	err := Set(cfg, "theme", 123)
+	if err == nil {
+		t.Error("expected error for non-string theme")
+	}
+}
+
+func TestSet_ThemeNestedPath(t *testing.T) {
+	cfg := &domain.Config{}
+	err := Set(cfg, "theme.nested", "value")
+	if err == nil {
+		t.Error("expected error for nested theme path")
+	}
+}
+
+func TestSet_UnknownTopLevel(t *testing.T) {
+	cfg := &domain.Config{}
+	err := Set(cfg, "bogus", "value")
+	if err == nil {
+		t.Error("expected error for unknown top-level key")
+	}
+}
+
+func TestSet_VarsIncompletePath(t *testing.T) {
+	cfg := &domain.Config{}
+	err := Set(cfg, "vars", "value")
+	if err == nil {
+		t.Error("expected error for incomplete vars path")
+	}
+}
+
+func TestSet_VarsUnknownScope(t *testing.T) {
+	cfg := &domain.Config{}
+	err := Set(cfg, "vars.unknown.key", "value")
+	if err == nil {
+		t.Error("expected error for unknown vars scope")
+	}
+}
+
+func TestSet_CatalogRunbookIncompletePath(t *testing.T) {
+	cfg := newTestConfig()
+	err := Set(cfg, "vars.catalog.default.runbooks", "value")
+	if err == nil {
+		t.Error("expected error for incomplete runbook path")
+	}
+}
+
+func TestSet_CatalogIncompletePath(t *testing.T) {
+	cfg := &domain.Config{}
+	err := Set(cfg, "vars.catalog", "value")
+	if err == nil {
+		t.Error("expected error for incomplete catalog path")
+	}
+}
+
+// --- Tests for Unset uncovered branches ---
+
+func TestUnset_NonVarsPath(t *testing.T) {
+	cfg := newTestConfig()
+	err := Unset(cfg, "theme")
+	if err == nil {
+		t.Error("expected error for non-vars unset path")
+	}
+}
+
+func TestUnset_IncompletePath(t *testing.T) {
+	cfg := newTestConfig()
+	err := Unset(cfg, "vars.global")
+	if err == nil {
+		t.Error("expected error for incomplete unset path")
+	}
+}
+
+func TestUnset_UnknownScope(t *testing.T) {
+	cfg := newTestConfig()
+	err := Unset(cfg, "vars.unknown.key")
+	if err == nil {
+		t.Error("expected error for unknown vars scope in unset")
+	}
+}
+
+func TestUnset_NilGlobalMap(t *testing.T) {
+	cfg := &domain.Config{Vars: domain.Vars{Global: nil}}
+	err := Unset(cfg, "vars.global.key")
+	if err == nil {
+		t.Error("expected error for nil global map")
+	}
+}
+
+func TestUnset_MissingCatalog(t *testing.T) {
+	cfg := newTestConfig()
+	err := Unset(cfg, "vars.catalog.missing.key")
+	if err == nil {
+		t.Error("expected error for missing catalog in unset")
+	}
+}
+
+func TestUnset_MissingCatalogVar(t *testing.T) {
+	cfg := newTestConfig()
+	err := Unset(cfg, "vars.catalog.default.nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent catalog var")
+	}
+}
+
+func TestUnset_RunbookIncompletePath(t *testing.T) {
+	cfg := newTestConfig()
+	err := Unset(cfg, "vars.catalog.default.runbooks")
+	if err == nil {
+		t.Error("expected error for incomplete runbook unset path")
+	}
+}
+
+func TestUnset_RunbookMissing(t *testing.T) {
+	cfg := newTestConfig()
+	err := Unset(cfg, "vars.catalog.default.runbooks.missing.key")
+	if err == nil {
+		t.Error("expected error for missing runbook in unset")
+	}
+}
+
+func TestUnset_RunbookVarMissing(t *testing.T) {
+	cfg := newTestConfig()
+	err := Unset(cfg, "vars.catalog.default.runbooks.hello-world.missing")
+	if err == nil {
+		t.Error("expected error for missing var in runbook unset")
+	}
+}
+
+func TestUnset_CatalogIncompletePath(t *testing.T) {
+	cfg := newTestConfig()
+	err := Unset(cfg, "vars.catalog.default")
+	if err == nil {
+		t.Error("expected error for incomplete catalog unset path")
+	}
+}
+
+// --- Tests for EnsureDefaults uncovered branches ---
+
+type errorFS struct {
+	fakeFS
+	readErr  error
+	writeErr error
+}
+
+func (e *errorFS) ReadFile(path string) ([]byte, error) {
+	if e.readErr != nil {
+		return nil, e.readErr
+	}
+	return e.fakeFS.ReadFile(path)
+}
+
+func (e *errorFS) WriteFile(path string, data []byte, perm fs.FileMode) error {
+	if e.writeErr != nil {
+		return e.writeErr
+	}
+	return e.fakeFS.WriteFile(path, data, perm)
+}
+
+func TestEnsureDefaults_NonExistError(t *testing.T) {
+	// ReadFile returns a non-ErrNotExist error.
+	efs := &errorFS{
+		fakeFS:  *newFakeFS(),
+		readErr: fmt.Errorf("read config: %w", fmt.Errorf("disk failure")),
+	}
+	store := NewFileStore(efs, "/fake/config.json")
+
+	_, err := store.EnsureDefaults()
+	if err == nil {
+		t.Fatal("expected error for non-ErrNotExist read failure")
+	}
+}
+
+func TestEnsureDefaults_SaveFails(t *testing.T) {
+	efs := &errorFS{
+		fakeFS:   *newFakeFS(),
+		writeErr: fmt.Errorf("disk full"),
+	}
+	store := NewFileStore(efs, "/fake/config.json")
+
+	_, err := store.EnsureDefaults()
+	if err == nil {
+		t.Fatal("expected error when save fails during EnsureDefaults")
+	}
+}
+
+func TestLoad_InvalidJSON(t *testing.T) {
+	ffs := newFakeFS()
+	ffs.files["/fake/config.json"] = []byte("not json")
+	store := NewFileStore(ffs, "/fake/config.json")
+
+	_, err := store.Load()
+	if err == nil {
+		t.Fatal("expected error for invalid JSON in config file")
+	}
+}
+
+func TestDefaultConfig_Values(t *testing.T) {
+	cfg := defaultConfig()
+	if cfg.Theme != "github" {
+		t.Errorf("default theme = %q, want github", cfg.Theme)
+	}
+	if cfg.Defaults.MaxRiskLevel != domain.RiskMedium {
+		t.Errorf("default MaxRiskLevel = %q, want medium", cfg.Defaults.MaxRiskLevel)
+	}
+	if cfg.Catalogs == nil {
+		t.Error("default catalogs should not be nil")
+	}
+}
+
+// --- EnsureDefaults with corrupt existing file ---
+
+func TestEnsureDefaults_CorruptExistingFile(t *testing.T) {
+	ffs := newFakeFS()
+	ffs.files["/fake/config.json"] = []byte("{invalid json")
+	store := NewFileStore(ffs, "/fake/config.json")
+
+	_, err := store.EnsureDefaults()
+	if err == nil {
+		t.Fatal("expected error for corrupt existing config file")
+	}
+}
+
+// --- Save error paths ---
+
+type mkdirErrorFS struct {
+	fakeFS
+}
+
+func (e *mkdirErrorFS) MkdirAll(_ string, _ fs.FileMode) error {
+	return fmt.Errorf("permission denied")
+}
+
+func TestSave_MkdirFails(t *testing.T) {
+	efs := &mkdirErrorFS{fakeFS: *newFakeFS()}
+	store := NewFileStore(efs, "/fake/nested/config.json")
+
+	cfg := &domain.Config{Theme: "test"}
+	err := store.Save(cfg)
+	if err == nil {
+		t.Fatal("expected error when mkdir fails")
+	}
+}
+
+// Verify Save with invalid config does not produce error (json.MarshalIndent handles all domain types).
+func TestSave_RoundTripWithVarsExcluded(t *testing.T) {
+	ffs := newFakeFS()
+	store := NewFileStore(ffs, "/fake/config.json")
+
+	cfg := &domain.Config{
+		Theme:    "nord",
+		Defaults: domain.Defaults{MaxRiskLevel: domain.RiskHigh},
+		Catalogs: []domain.Catalog{
+			{Name: "test", Path: "/tmp/test", Active: true},
+		},
+	}
+
+	if err := store.Save(cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data := ffs.files["/fake/config.json"]
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := raw["vars"]; ok {
+		t.Error("vars should not appear in saved config")
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Theme != "nord" {
+		t.Errorf("theme = %q, want nord", loaded.Theme)
+	}
+	if loaded.Defaults.MaxRiskLevel != domain.RiskHigh {
+		t.Errorf("MaxRiskLevel = %q, want high", loaded.Defaults.MaxRiskLevel)
+	}
+	if len(loaded.Catalogs) != 1 {
+		t.Errorf("catalogs len = %d, want 1", len(loaded.Catalogs))
+	}
+}

--- a/internal/domain/config_test.go
+++ b/internal/domain/config_test.go
@@ -1,6 +1,8 @@
 package domain
 
 import (
+	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -115,5 +117,150 @@ func TestValidateDisplayName(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestCatalogVars_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		cv   CatalogVars
+		want map[string]any
+	}{
+		{
+			name: "vars only",
+			cv: CatalogVars{
+				Vars:     map[string]any{"region": "us-east-1", "env": "prod"},
+				Runbooks: nil,
+			},
+			want: map[string]any{"region": "us-east-1", "env": "prod"},
+		},
+		{
+			name: "vars with runbooks",
+			cv: CatalogVars{
+				Vars: map[string]any{"region": "us-east-1"},
+				Runbooks: map[string]map[string]any{
+					"deploy": {"version": "1.0"},
+				},
+			},
+			want: map[string]any{
+				"region": "us-east-1",
+				"runbooks": map[string]any{
+					"deploy": map[string]any{"version": "1.0"},
+				},
+			},
+		},
+		{
+			name: "empty vars no runbooks",
+			cv: CatalogVars{
+				Vars:     map[string]any{},
+				Runbooks: map[string]map[string]any{},
+			},
+			want: map[string]any{},
+		},
+		{
+			name: "nil vars nil runbooks",
+			cv:   CatalogVars{},
+			want: map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.cv)
+			if err != nil {
+				t.Fatalf("MarshalJSON: %v", err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal result: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCatalogVars_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantVars     map[string]any
+		wantRunbooks map[string]map[string]any
+		wantErr      bool
+	}{
+		{
+			name:         "flat vars only",
+			input:        `{"region":"us-east-1","env":"prod"}`,
+			wantVars:     map[string]any{"region": "us-east-1", "env": "prod"},
+			wantRunbooks: map[string]map[string]any{},
+		},
+		{
+			name:  "vars with runbooks",
+			input: `{"region":"us-east-1","runbooks":{"deploy":{"version":"1.0"}}}`,
+			wantVars: map[string]any{"region": "us-east-1"},
+			wantRunbooks: map[string]map[string]any{
+				"deploy": {"version": "1.0"},
+			},
+		},
+		{
+			name:         "empty object",
+			input:        `{}`,
+			wantVars:     map[string]any{},
+			wantRunbooks: map[string]map[string]any{},
+		},
+		{
+			name:    "invalid JSON",
+			input:   `not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cv CatalogVars
+			err := json.Unmarshal([]byte(tt.input), &cv)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UnmarshalJSON: %v", err)
+			}
+			if !reflect.DeepEqual(cv.Vars, tt.wantVars) {
+				t.Errorf("Vars = %v, want %v", cv.Vars, tt.wantVars)
+			}
+			if !reflect.DeepEqual(cv.Runbooks, tt.wantRunbooks) {
+				t.Errorf("Runbooks = %v, want %v", cv.Runbooks, tt.wantRunbooks)
+			}
+		})
+	}
+}
+
+func TestCatalogVars_RoundTrip(t *testing.T) {
+	original := CatalogVars{
+		Vars: map[string]any{"key": "value", "count": float64(42)},
+		Runbooks: map[string]map[string]any{
+			"deploy": {"target": "prod"},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var decoded CatalogVars
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if !reflect.DeepEqual(original.Vars, decoded.Vars) {
+		t.Errorf("Vars mismatch after round-trip: got %v, want %v", decoded.Vars, original.Vars)
+	}
+	if !reflect.DeepEqual(original.Runbooks, decoded.Runbooks) {
+		t.Errorf("Runbooks mismatch after round-trip: got %v, want %v", decoded.Runbooks, original.Runbooks)
 	}
 }

--- a/internal/executor/demo_test.go
+++ b/internal/executor/demo_test.go
@@ -1,0 +1,189 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestNewDemoRunner(t *testing.T) {
+	runner := NewDemoRunner()
+	if runner == nil {
+		t.Fatal("NewDemoRunner returned nil")
+	}
+}
+
+func TestDemoRunner_Run_KnownRunbook(t *testing.T) {
+	runner := NewDemoRunner()
+	// Script path structure: .../hello-world/run.sh -> name = "hello-world"
+	scriptPath := "/fake/catalogs/hello-world/run.sh"
+	env := map[string]string{"MESSAGE": "demo"}
+
+	lines, errs := runner.Run(context.Background(), scriptPath, env)
+	collected, err := collectOutput(t, lines, errs)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(collected) == 0 {
+		t.Fatal("expected output lines, got none")
+	}
+
+	// hello-world runbook should produce "Hello, demo!" after env resolution.
+	found := false
+	for _, line := range collected {
+		if line.Text == "Hello, demo!" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected resolved line %q in output, got: %v", "Hello, demo!", outputTexts(collected))
+	}
+}
+
+func TestDemoRunner_Run_UnknownRunbook(t *testing.T) {
+	runner := NewDemoRunner()
+	// Unknown runbook name should produce generic fallback output.
+	scriptPath := "/fake/catalogs/unknown-task/run.sh"
+
+	lines, errs := runner.Run(context.Background(), scriptPath, nil)
+	collected, err := collectOutput(t, lines, errs)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(collected) == 0 {
+		t.Fatal("expected fallback output, got none")
+	}
+
+	// Generic output should contain the runbook name and a success message.
+	wantFirst := "$ unknown-task"
+	if collected[0].Text != wantFirst {
+		t.Errorf("first line = %q, want %q", collected[0].Text, wantFirst)
+	}
+
+	lastLine := collected[len(collected)-1].Text
+	want := fmt.Sprintf("\033[32m✓\033[0m %s completed successfully", "unknown-task")
+	if lastLine != want {
+		t.Errorf("last line = %q, want %q", lastLine, want)
+	}
+}
+
+func TestDemoRunner_Run_ContextCancelled(t *testing.T) {
+	runner := NewDemoRunner()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	lines, errs := runner.Run(ctx, "/fake/catalogs/deploy-app/run.sh", nil)
+	_, err := collectOutput(t, lines, errs)
+
+	if err == nil {
+		// Cancellation may or may not be caught depending on timing with
+		// the sleep. Either an error or a short output is acceptable.
+		t.Log("no error returned (cancellation may not have been caught before first line)")
+	}
+}
+
+func TestDemoOutput_KnownRunbook(t *testing.T) {
+	env := map[string]string{"SERVICE": "api-server"}
+	out := demoOutput("service-status", env)
+
+	if len(out) == 0 {
+		t.Fatal("expected output for known runbook")
+	}
+	if out[0] != "$ service-status" {
+		t.Errorf("first line = %q, want %q", out[0], "$ service-status")
+	}
+
+	// Env var should be resolved.
+	found := false
+	for _, line := range out {
+		if line == "Checking service: api-server..." {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected env var to be resolved in output, got: %v", out)
+	}
+}
+
+func TestDemoOutput_FallbackForUnknown(t *testing.T) {
+	out := demoOutput("nonexistent-runbook", nil)
+
+	if len(out) == 0 {
+		t.Fatal("expected fallback output")
+	}
+	if out[0] != "$ nonexistent-runbook" {
+		t.Errorf("first line = %q, want %q", out[0], "$ nonexistent-runbook")
+	}
+}
+
+func TestResolveEnv(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		env   map[string]string
+		want  []string
+	}{
+		{
+			name:  "single replacement",
+			lines: []string{"Hello, ${NAME}!"},
+			env:   map[string]string{"NAME": "world"},
+			want:  []string{"Hello, world!"},
+		},
+		{
+			name:  "multiple vars in one line",
+			lines: []string{"${HOST}:${PORT}"},
+			env:   map[string]string{"HOST": "localhost", "PORT": "8080"},
+			want:  []string{"localhost:8080"},
+		},
+		{
+			name:  "no replacements needed",
+			lines: []string{"plain text"},
+			env:   map[string]string{"UNUSED": "value"},
+			want:  []string{"plain text"},
+		},
+		{
+			name:  "nil env",
+			lines: []string{"${VAR} stays"},
+			env:   nil,
+			want:  []string{"${VAR} stays"},
+		},
+		{
+			name:  "empty lines",
+			lines: []string{},
+			env:   map[string]string{"X": "Y"},
+			want:  []string{},
+		},
+		{
+			name:  "repeated var",
+			lines: []string{"${V} and ${V}"},
+			env:   map[string]string{"V": "ok"},
+			want:  []string{"ok and ok"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveEnv(tt.lines, tt.env)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("line[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func outputTexts(lines []OutputLine) []string {
+	out := make([]string, len(lines))
+	for i, l := range lines {
+		out[i] = l.Text
+	}
+	return out
+}

--- a/internal/mcp/mcp_extra_test.go
+++ b/internal/mcp/mcp_extra_test.go
@@ -1,0 +1,551 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"dops/internal/domain"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// --- isYAMLFile tests (0% covered) ---
+
+func TestIsYAMLFile(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"runbook.yaml", true},
+		{"runbook.yml", true},
+		{"runbook.YAML", true},
+		{"runbook.YML", true},
+		{"runbook.Yaml", true},
+		{"path/to/file.yaml", true},
+		{"path/to/file.yml", true},
+		{"runbook.json", false},
+		{"runbook.txt", false},
+		{"runbook", false},
+		{"", false},
+		{".yaml", true},
+		{".yml", true},
+		{"file.yaml.bak", false},
+		{"yaml", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isYAMLFile(tt.name)
+			if got != tt.want {
+				t.Errorf("isYAMLFile(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- isWriteEvent tests (0% covered) ---
+
+func TestIsWriteEvent(t *testing.T) {
+	tests := []struct {
+		name string
+		op   fsnotify.Op
+		want bool
+	}{
+		{"Write", fsnotify.Write, true},
+		{"Create", fsnotify.Create, true},
+		{"Remove", fsnotify.Remove, true},
+		{"Rename", fsnotify.Rename, true},
+		{"Chmod", fsnotify.Chmod, false},
+		{"Write|Create", fsnotify.Write | fsnotify.Create, true},
+		{"Chmod|Write", fsnotify.Chmod | fsnotify.Write, true},
+		{"NoOp", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := fsnotify.Event{Name: "test.yaml", Op: tt.op}
+			got := isWriteEvent(e)
+			if got != tt.want {
+				t.Errorf("isWriteEvent(op=%v) = %v, want %v", tt.op, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- validateRiskConfirmation tests (25% covered) ---
+
+func TestValidateRiskConfirmation_LowRisk(t *testing.T) {
+	rb := domain.Runbook{ID: "test.rb", RiskLevel: domain.RiskLow}
+	err := validateRiskConfirmation(rb, nil)
+	if err != nil {
+		t.Errorf("low risk should not require confirmation: %v", err)
+	}
+}
+
+func TestValidateRiskConfirmation_MediumRisk(t *testing.T) {
+	rb := domain.Runbook{ID: "test.rb", RiskLevel: domain.RiskMedium}
+	err := validateRiskConfirmation(rb, nil)
+	if err != nil {
+		t.Errorf("medium risk should not require confirmation: %v", err)
+	}
+}
+
+func TestValidateRiskConfirmation_HighRisk_Correct(t *testing.T) {
+	rb := domain.Runbook{ID: "infra.deploy", RiskLevel: domain.RiskHigh}
+	args := map[string]any{"_confirm_id": "infra.deploy"}
+	err := validateRiskConfirmation(rb, args)
+	if err != nil {
+		t.Errorf("correct confirm_id should pass: %v", err)
+	}
+}
+
+func TestValidateRiskConfirmation_HighRisk_Wrong(t *testing.T) {
+	rb := domain.Runbook{ID: "infra.deploy", RiskLevel: domain.RiskHigh}
+	args := map[string]any{"_confirm_id": "wrong-id"}
+	err := validateRiskConfirmation(rb, args)
+	if err == nil {
+		t.Error("wrong confirm_id should fail")
+	}
+}
+
+func TestValidateRiskConfirmation_HighRisk_Missing(t *testing.T) {
+	rb := domain.Runbook{ID: "infra.deploy", RiskLevel: domain.RiskHigh}
+	err := validateRiskConfirmation(rb, map[string]any{})
+	if err == nil {
+		t.Error("missing confirm_id should fail")
+	}
+}
+
+func TestValidateRiskConfirmation_HighRisk_NilArgs(t *testing.T) {
+	rb := domain.Runbook{ID: "infra.deploy", RiskLevel: domain.RiskHigh}
+	err := validateRiskConfirmation(rb, nil)
+	if err == nil {
+		t.Error("nil args should fail for high risk")
+	}
+}
+
+func TestValidateRiskConfirmation_CriticalRisk_Correct(t *testing.T) {
+	rb := domain.Runbook{ID: "infra.nuke", RiskLevel: domain.RiskCritical}
+	args := map[string]any{"_confirm_word": "CONFIRM"}
+	err := validateRiskConfirmation(rb, args)
+	if err != nil {
+		t.Errorf("correct confirm_word should pass: %v", err)
+	}
+}
+
+func TestValidateRiskConfirmation_CriticalRisk_Wrong(t *testing.T) {
+	rb := domain.Runbook{ID: "infra.nuke", RiskLevel: domain.RiskCritical}
+	args := map[string]any{"_confirm_word": "confirm"}
+	err := validateRiskConfirmation(rb, args)
+	if err == nil {
+		t.Error("lowercase confirm should fail for critical risk")
+	}
+}
+
+func TestValidateRiskConfirmation_CriticalRisk_Missing(t *testing.T) {
+	rb := domain.Runbook{ID: "infra.nuke", RiskLevel: domain.RiskCritical}
+	err := validateRiskConfirmation(rb, map[string]any{})
+	if err == nil {
+		t.Error("missing confirm_word should fail for critical risk")
+	}
+}
+
+func TestValidateRiskConfirmation_EmptyRiskLevel(t *testing.T) {
+	rb := domain.Runbook{ID: "test.rb", RiskLevel: ""}
+	err := validateRiskConfirmation(rb, nil)
+	if err != nil {
+		t.Errorf("empty risk level should not require confirmation: %v", err)
+	}
+}
+
+// --- paramToSchemaProperty / RunbookToInputSchema additional tests (39.3% covered) ---
+
+func TestRunbookToInputSchema_NumberType(t *testing.T) {
+	rb := domain.Runbook{
+		ID: "test.rb",
+		Parameters: []domain.Parameter{
+			{Name: "replicas", Type: domain.ParamNumber},
+		},
+	}
+
+	schema, _ := RunbookToInputSchema(rb, nil)
+	var parsed map[string]any
+	json.Unmarshal(schema, &parsed)
+
+	props := parsed["properties"].(map[string]any)
+	prop := props["replicas"].(map[string]any)
+	if prop["type"] != "integer" {
+		t.Errorf("number type should map to integer, got %v", prop["type"])
+	}
+	if prop["minimum"] != float64(0) {
+		t.Errorf("number type should have minimum 0, got %v", prop["minimum"])
+	}
+}
+
+func TestRunbookToInputSchema_FloatType(t *testing.T) {
+	rb := domain.Runbook{
+		ID: "test.rb",
+		Parameters: []domain.Parameter{
+			{Name: "ratio", Type: domain.ParamFloat},
+		},
+	}
+
+	schema, _ := RunbookToInputSchema(rb, nil)
+	var parsed map[string]any
+	json.Unmarshal(schema, &parsed)
+
+	props := parsed["properties"].(map[string]any)
+	prop := props["ratio"].(map[string]any)
+	if prop["type"] != "number" {
+		t.Errorf("float type should map to number, got %v", prop["type"])
+	}
+}
+
+func TestRunbookToInputSchema_MultiSelectType(t *testing.T) {
+	rb := domain.Runbook{
+		ID: "test.rb",
+		Parameters: []domain.Parameter{
+			{Name: "regions", Type: domain.ParamMultiSelect, Options: []string{"us", "eu"}},
+		},
+	}
+
+	schema, _ := RunbookToInputSchema(rb, nil)
+	var parsed map[string]any
+	json.Unmarshal(schema, &parsed)
+
+	props := parsed["properties"].(map[string]any)
+	prop := props["regions"].(map[string]any)
+	if prop["type"] != "array" {
+		t.Errorf("multi_select type should map to array, got %v", prop["type"])
+	}
+	items := prop["items"].(map[string]any)
+	if items["type"] != "string" {
+		t.Errorf("items type should be string, got %v", items["type"])
+	}
+}
+
+func TestRunbookToInputSchema_MultiSelectNoOptions(t *testing.T) {
+	rb := domain.Runbook{
+		ID: "test.rb",
+		Parameters: []domain.Parameter{
+			{Name: "tags", Type: domain.ParamMultiSelect},
+		},
+	}
+
+	schema, _ := RunbookToInputSchema(rb, nil)
+	var parsed map[string]any
+	json.Unmarshal(schema, &parsed)
+
+	props := parsed["properties"].(map[string]any)
+	prop := props["tags"].(map[string]any)
+	items := prop["items"].(map[string]any)
+	if _, hasEnum := items["enum"]; hasEnum {
+		t.Error("multi_select with no options should not have enum in items")
+	}
+}
+
+func TestRunbookToInputSchema_FilePathType(t *testing.T) {
+	rb := domain.Runbook{
+		ID: "test.rb",
+		Parameters: []domain.Parameter{
+			{Name: "config", Type: domain.ParamFilePath},
+		},
+	}
+
+	schema, _ := RunbookToInputSchema(rb, nil)
+	var parsed map[string]any
+	json.Unmarshal(schema, &parsed)
+
+	props := parsed["properties"].(map[string]any)
+	prop := props["config"].(map[string]any)
+	if prop["type"] != "string" {
+		t.Errorf("file_path type should map to string, got %v", prop["type"])
+	}
+}
+
+func TestRunbookToInputSchema_ResourceIDType(t *testing.T) {
+	rb := domain.Runbook{
+		ID: "test.rb",
+		Parameters: []domain.Parameter{
+			{Name: "resource", Type: domain.ParamResourceID},
+		},
+	}
+
+	schema, _ := RunbookToInputSchema(rb, nil)
+	var parsed map[string]any
+	json.Unmarshal(schema, &parsed)
+
+	props := parsed["properties"].(map[string]any)
+	prop := props["resource"].(map[string]any)
+	if prop["type"] != "string" {
+		t.Errorf("resource_id type should map to string, got %v", prop["type"])
+	}
+	if prop["description"] != "resource identifier" {
+		t.Errorf("resource_id should have description 'resource identifier', got %v", prop["description"])
+	}
+}
+
+func TestRunbookToInputSchema_WithDefault(t *testing.T) {
+	rb := domain.Runbook{
+		ID: "test.rb",
+		Parameters: []domain.Parameter{
+			{Name: "env", Type: domain.ParamString, Default: "dev"},
+		},
+	}
+
+	schema, _ := RunbookToInputSchema(rb, nil)
+	var parsed map[string]any
+	json.Unmarshal(schema, &parsed)
+
+	props := parsed["properties"].(map[string]any)
+	prop := props["env"].(map[string]any)
+	if prop["default"] != "dev" {
+		t.Errorf("default should be 'dev', got %v", prop["default"])
+	}
+}
+
+func TestRunbookToInputSchema_ResolvedParamOptional(t *testing.T) {
+	rb := domain.Runbook{
+		ID: "test.rb",
+		Parameters: []domain.Parameter{
+			{Name: "region", Type: domain.ParamString, Required: true, Description: "AWS region"},
+		},
+	}
+
+	resolved := map[string]string{"region": "us-east-1"}
+	schema, _ := RunbookToInputSchema(rb, resolved)
+	var parsed map[string]any
+	json.Unmarshal(schema, &parsed)
+
+	// Resolved required param should NOT be in required list.
+	if req, ok := parsed["required"]; ok {
+		reqList := req.([]any)
+		for _, r := range reqList {
+			if r == "region" {
+				t.Error("resolved param 'region' should not be required")
+			}
+		}
+	}
+}
+
+func TestRunbookToInputSchema_HighRiskConfirmation(t *testing.T) {
+	rb := domain.Runbook{
+		ID:        "infra.deploy",
+		RiskLevel: domain.RiskHigh,
+	}
+
+	schema, _ := RunbookToInputSchema(rb, nil)
+	var parsed map[string]any
+	json.Unmarshal(schema, &parsed)
+
+	props := parsed["properties"].(map[string]any)
+	if _, exists := props["_confirm_id"]; !exists {
+		t.Error("high risk should have _confirm_id field")
+	}
+}
+
+func TestRunbookToInputSchema_SelectNoOptions(t *testing.T) {
+	rb := domain.Runbook{
+		ID: "test.rb",
+		Parameters: []domain.Parameter{
+			{Name: "env", Type: domain.ParamSelect},
+		},
+	}
+
+	schema, _ := RunbookToInputSchema(rb, nil)
+	var parsed map[string]any
+	json.Unmarshal(schema, &parsed)
+
+	props := parsed["properties"].(map[string]any)
+	prop := props["env"].(map[string]any)
+	if _, hasEnum := prop["enum"]; hasEnum {
+		t.Error("select with no options should not have enum")
+	}
+}
+
+func TestRunbookToInputSchema_NoRequired(t *testing.T) {
+	rb := domain.Runbook{
+		ID: "test.rb",
+		Parameters: []domain.Parameter{
+			{Name: "optional", Type: domain.ParamString},
+		},
+	}
+
+	schema, _ := RunbookToInputSchema(rb, nil)
+	var parsed map[string]any
+	json.Unmarshal(schema, &parsed)
+
+	if _, ok := parsed["required"]; ok {
+		t.Error("schema with no required params should not have required field")
+	}
+}
+
+// --- collectResult tests ---
+
+func TestCollectResult_TruncatesOutput(t *testing.T) {
+	// Build exactly maxToolOutputLines+5 lines.
+	lines := make([]string, maxToolOutputLines+5)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line-%d", i)
+	}
+
+	result := collectResult(lines, time.Now(), "/tmp/test.log", nil)
+
+	outputLines := strings.Split(result.Output, "\n")
+	// Output should be last maxToolOutputLines lines joined.
+	if !strings.Contains(result.Output, fmt.Sprintf("line-%d", maxToolOutputLines+4)) {
+		t.Error("truncated output should contain last line")
+	}
+	if strings.Contains(result.Output, "line-0") {
+		t.Error("truncated output should not contain first line")
+	}
+	// Verify boundary: exactly maxToolOutputLines should NOT truncate.
+	exactLines := make([]string, maxToolOutputLines)
+	for i := range exactLines {
+		exactLines[i] = fmt.Sprintf("exact-%d", i)
+	}
+	exactResult := collectResult(exactLines, time.Now(), "", nil)
+	if !strings.Contains(exactResult.Output, "exact-0") {
+		t.Error("exactly maxToolOutputLines should not truncate — first line should be present")
+	}
+	_ = outputLines
+}
+
+func TestCollectResult_ExitCode(t *testing.T) {
+	// No error → exit code 0.
+	r := collectResult([]string{"ok"}, time.Now(), "", nil)
+	if r.ExitCode != 0 {
+		t.Errorf("exit code = %d, want 0", r.ExitCode)
+	}
+
+	// With error → exit code 1.
+	r = collectResult([]string{"fail"}, time.Now(), "", fmt.Errorf("oops"))
+	if r.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1", r.ExitCode)
+	}
+}
+
+func TestCollectResult_Summary(t *testing.T) {
+	// Summary is last non-empty line.
+	r := collectResult([]string{"first", "middle", "last", ""}, time.Now(), "", nil)
+	if r.Summary != "last" {
+		t.Errorf("summary = %q, want 'last'", r.Summary)
+	}
+
+	// Empty lines → empty summary.
+	r = collectResult([]string{""}, time.Now(), "", nil)
+	if r.Summary != "" {
+		t.Errorf("summary = %q, want empty", r.Summary)
+	}
+}
+
+func TestCollectResult_LogPath(t *testing.T) {
+	r := collectResult([]string{"ok"}, time.Now(), "/tmp/run.log", nil)
+	if r.LogPath != "/tmp/run.log" {
+		t.Errorf("log path = %q, want /tmp/run.log", r.LogPath)
+	}
+}
+
+// --- prepareExecution tests ---
+
+func TestPrepareExecution_MergesArgs(t *testing.T) {
+	req := ToolCallRequest{
+		Runbook: domain.Runbook{
+			Name:      "test-rb",
+			Script:    "run.sh",
+			RiskLevel: domain.RiskLow,
+			Parameters: []domain.Parameter{
+				{Name: "region", Scope: "global"},
+			},
+		},
+		Catalog: domain.Catalog{
+			Name: "default",
+			Path: t.TempDir(),
+		},
+		Config: &domain.Config{
+			Vars: domain.Vars{
+				Global: map[string]any{"region": "us-east-1"},
+			},
+		},
+		Args: map[string]any{
+			"region":      "eu-west-1",
+			"_confirm_id": "test-rb", // should be skipped
+		},
+	}
+
+	_, env, err := prepareExecution(req)
+	if err != nil {
+		t.Fatalf("prepareExecution: %v", err)
+	}
+	// Args should override resolved vars.
+	if env["REGION"] != "eu-west-1" {
+		t.Errorf("REGION = %q, want eu-west-1", env["REGION"])
+	}
+	// Confirm fields should be excluded.
+	if _, ok := env["_CONFIRM_ID"]; ok {
+		t.Error("_confirm_id should be excluded from env")
+	}
+}
+
+func TestPrepareExecution_FailsOnRiskValidation(t *testing.T) {
+	req := ToolCallRequest{
+		Runbook: domain.Runbook{
+			Name:      "test-rb",
+			Script:    "run.sh",
+			RiskLevel: domain.RiskHigh,
+			ID:        "default.test-rb",
+		},
+		Catalog: domain.Catalog{Name: "default", Path: "/tmp"},
+		Config:  &domain.Config{},
+		Args:    map[string]any{}, // missing _confirm_id
+	}
+
+	_, _, err := prepareExecution(req)
+	if err == nil {
+		t.Error("should fail when high-risk confirmation is missing")
+	}
+}
+
+// --- RunbookToDescription additional tests ---
+
+func TestRunbookToDescription_WithAliases(t *testing.T) {
+	rb := domain.Runbook{
+		ID:          "test.deploy",
+		Description: "Deploy app",
+		Aliases:     []string{"d", "dep"},
+	}
+
+	desc := RunbookToDescription(rb)
+	if desc != "Deploy app [aliases: d, dep]" {
+		t.Errorf("description = %q, unexpected", desc)
+	}
+}
+
+func TestRunbookToDescription_NoExtras(t *testing.T) {
+	rb := domain.Runbook{
+		ID:          "test.simple",
+		Description: "Simple task",
+	}
+
+	desc := RunbookToDescription(rb)
+	if desc != "Simple task" {
+		t.Errorf("description = %q, want 'Simple task'", desc)
+	}
+}
+
+func TestRunbookToDescription_RiskOnly(t *testing.T) {
+	rb := domain.Runbook{
+		ID:          "test.risky",
+		Description: "Risky op",
+		RiskLevel:   domain.RiskHigh,
+	}
+
+	desc := RunbookToDescription(rb)
+	expected := "Risky op [risk: high]"
+	if desc != expected {
+		t.Errorf("description = %q, want %q", desc, expected)
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,8 +1,12 @@
 package mcp
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -186,5 +190,253 @@ func TestServer_ToolCall(t *testing.T) {
 	}
 	if !strings.Contains(text, "Exit code: 0") {
 		t.Error("should contain exit code")
+	}
+}
+
+func TestServer_MaxRiskFilters(t *testing.T) {
+	cats := []catalog.CatalogWithRunbooks{
+		{
+			Catalog: domain.Catalog{Name: "test", Path: filepath.Join(os.TempDir(), "test")},
+			Runbooks: []domain.Runbook{
+				{ID: "test.low", Name: "low", RiskLevel: domain.RiskLow, Script: "s.sh"},
+				{ID: "test.high", Name: "high", RiskLevel: domain.RiskHigh, Script: "s.sh"},
+				{ID: "test.critical", Name: "critical", RiskLevel: domain.RiskCritical, Script: "s.sh"},
+			},
+		},
+	}
+
+	srv := NewServer(ServerConfig{
+		Version:  "test",
+		Catalogs: cats,
+		Runner:   &fakeRunner{},
+		Config:   &domain.Config{},
+		MaxRisk:  domain.RiskLow,
+	})
+
+	ctx := context.Background()
+	t1, t2 := mcpsdk.NewInMemoryTransports()
+	srv.srv.Connect(ctx, t1, nil)
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test", Version: "1.0"}, nil)
+	session, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	var tools []*mcpsdk.Tool
+	for tool, err := range session.Tools(ctx, nil) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		tools = append(tools, tool)
+	}
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool (low only), got %d", len(tools))
+	}
+	if tools[0].Name != "test.low" {
+		t.Errorf("expected test.low, got %s", tools[0].Name)
+	}
+}
+
+func TestServer_SchemaResources(t *testing.T) {
+	srv := NewServer(ServerConfig{
+		Version:  "test",
+		Catalogs: testCatalogs(),
+		Runner:   &fakeRunner{},
+		Config:   &domain.Config{},
+	})
+
+	ctx := context.Background()
+	t1, t2 := mcpsdk.NewInMemoryTransports()
+	srv.srv.Connect(ctx, t1, nil)
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test", Version: "1.0"}, nil)
+	session, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	tests := []struct {
+		uri      string
+		contains string
+	}{
+		{"dops://schema/runbook", "runbook.yaml"},
+		{"dops://schema/shell-style", "Shell Script Style Guide"},
+	}
+
+	for _, tt := range tests {
+		result, err := session.ReadResource(ctx, &mcpsdk.ReadResourceParams{URI: tt.uri})
+		if err != nil {
+			t.Fatalf("ReadResource(%s): %v", tt.uri, err)
+		}
+		if len(result.Contents) == 0 {
+			t.Fatalf("ReadResource(%s): no contents", tt.uri)
+		}
+		if !strings.Contains(result.Contents[0].Text, tt.contains) {
+			t.Errorf("ReadResource(%s) should contain %q", tt.uri, tt.contains)
+		}
+	}
+}
+
+func TestServer_Prompts(t *testing.T) {
+	srv := NewServer(ServerConfig{
+		Version:  "test",
+		DopsHome: "/tmp/test-dops",
+		Catalogs: testCatalogs(),
+		Runner:   &fakeRunner{},
+		Config:   &domain.Config{},
+	})
+
+	ctx := context.Background()
+	t1, t2 := mcpsdk.NewInMemoryTransports()
+	srv.srv.Connect(ctx, t1, nil)
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test", Version: "1.0"}, nil)
+	session, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	result, err := session.GetPrompt(ctx, &mcpsdk.GetPromptParams{
+		Name: "create-runbook",
+		Arguments: map[string]string{
+			"catalog":     "infra",
+			"name":        "check-health",
+			"description": "Check service health",
+			"risk_level":  "medium",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Messages) == 0 {
+		t.Fatal("expected prompt messages")
+	}
+
+	text := result.Messages[0].Content.(*mcpsdk.TextContent).Text
+	if !strings.Contains(text, "check-health") {
+		t.Error("prompt should contain runbook name")
+	}
+	if !strings.Contains(text, "/tmp/test-dops") {
+		t.Error("prompt should contain dops home path")
+	}
+	if !strings.Contains(text, "medium") {
+		t.Error("prompt should contain risk level")
+	}
+}
+
+func TestToolError(t *testing.T) {
+	result := toolError("something broke")
+	if !result.IsError {
+		t.Error("expected IsError=true")
+	}
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	if text != "something broke" {
+		t.Errorf("got %q, want %q", text, "something broke")
+	}
+}
+
+func TestGzipMiddleware_CompressesResponse(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hello world"))
+	})
+
+	handler := gzipMiddleware(inner)
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Content-Encoding") != "gzip" {
+		t.Error("expected Content-Encoding: gzip")
+	}
+
+	gr, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatal("failed to create gzip reader:", err)
+	}
+	defer gr.Close()
+
+	body, _ := io.ReadAll(gr)
+	if string(body) != "hello world" {
+		t.Errorf("got %q, want %q", string(body), "hello world")
+	}
+}
+
+func TestGzipMiddleware_SkipsWithoutAcceptEncoding(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hello world"))
+	})
+
+	handler := gzipMiddleware(inner)
+	req := httptest.NewRequest("GET", "/", nil)
+	// No Accept-Encoding header.
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Content-Encoding") == "gzip" {
+		t.Error("should not gzip without Accept-Encoding")
+	}
+	if rec.Body.String() != "hello world" {
+		t.Errorf("got %q", rec.Body.String())
+	}
+}
+
+func TestGzipMiddleware_SkipsSSE(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("event: data\n"))
+	})
+
+	handler := gzipMiddleware(inner)
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set("Accept", "text/event-stream")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Content-Encoding") == "gzip" {
+		t.Error("should not gzip SSE responses")
+	}
+}
+
+func TestServer_RunbookDetailResource(t *testing.T) {
+	srv := NewServer(ServerConfig{
+		Version:  "test",
+		Catalogs: testCatalogs(),
+		Runner:   &fakeRunner{},
+		Config:   &domain.Config{},
+	})
+
+	ctx := context.Background()
+	t1, t2 := mcpsdk.NewInMemoryTransports()
+	srv.srv.Connect(ctx, t1, nil)
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test", Version: "1.0"}, nil)
+	session, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	result, err := session.ReadResource(ctx, &mcpsdk.ReadResourceParams{URI: "dops://catalog/default.echo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Contents) == 0 {
+		t.Fatal("expected resource contents")
+	}
+
+	text := result.Contents[0].Text
+	if !strings.Contains(text, "default.echo") {
+		t.Error("detail should contain runbook ID")
 	}
 }

--- a/internal/tui/app_extra_test.go
+++ b/internal/tui/app_extra_test.go
@@ -1,0 +1,1384 @@
+package tui
+
+import (
+	"dops/internal/domain"
+	"dops/internal/testutil"
+	"dops/internal/tui/confirm"
+	"dops/internal/tui/footer"
+	"dops/internal/tui/output"
+	"dops/internal/tui/palette"
+	"dops/internal/tui/sidebar"
+	"dops/internal/tui/wizard"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+// ---------------------------------------------------------------------------
+// Pure helper: isMouseMsg
+// ---------------------------------------------------------------------------
+
+func TestIsMouseMsg(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  tea.Msg
+		want bool
+	}{
+		{"MouseClickMsg", tea.MouseClickMsg{X: 1, Y: 2, Button: tea.MouseLeft}, true},
+		{"MouseMotionMsg", tea.MouseMotionMsg{X: 1, Y: 2}, true},
+		{"MouseReleaseMsg", tea.MouseReleaseMsg{X: 1, Y: 2}, true},
+		{"MouseWheelMsg", tea.MouseWheelMsg{X: 1, Y: 2}, true},
+		{"KeyPressMsg", tea.KeyPressMsg{Code: 'a'}, false},
+		{"WindowSizeMsg", tea.WindowSizeMsg{Width: 80, Height: 24}, false},
+		{"nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMouseMsg(tt.msg); got != tt.want {
+				t.Errorf("isMouseMsg(%T) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper: isMouseClick
+// ---------------------------------------------------------------------------
+
+func TestIsMouseClick(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  tea.Msg
+		want bool
+	}{
+		{"MouseClickMsg", tea.MouseClickMsg{X: 1, Y: 2, Button: tea.MouseLeft}, true},
+		{"MouseMotionMsg", tea.MouseMotionMsg{X: 1, Y: 2}, false},
+		{"KeyPressMsg", tea.KeyPressMsg{Code: 'a'}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMouseClick(tt.msg); got != tt.want {
+				t.Errorf("isMouseClick(%T) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper: mouseCoords
+// ---------------------------------------------------------------------------
+
+func TestMouseCoords(t *testing.T) {
+	tests := []struct {
+		name   string
+		msg    tea.Msg
+		wantX  int
+		wantY  int
+		wantOk bool
+	}{
+		{"MouseClickMsg", tea.MouseClickMsg{X: 10, Y: 20, Button: tea.MouseLeft}, 10, 20, true},
+		{"MouseReleaseMsg", tea.MouseReleaseMsg{X: 5, Y: 15}, 5, 15, true},
+		{"MouseMotionMsg", tea.MouseMotionMsg{X: 3, Y: 7}, 3, 7, true},
+		{"MouseWheelMsg", tea.MouseWheelMsg{X: 8, Y: 12}, 8, 12, true},
+		{"KeyPressMsg", tea.KeyPressMsg{Code: 'a'}, 0, 0, false},
+		{"nil", nil, 0, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x, y, ok := mouseCoords(tt.msg)
+			if x != tt.wantX || y != tt.wantY || ok != tt.wantOk {
+				t.Errorf("mouseCoords(%T) = (%d, %d, %v), want (%d, %d, %v)",
+					tt.msg, x, y, ok, tt.wantX, tt.wantY, tt.wantOk)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper: clamp
+// ---------------------------------------------------------------------------
+
+func TestClamp(t *testing.T) {
+	tests := []struct {
+		v, min, want int
+	}{
+		{5, 3, 5},
+		{3, 3, 3},
+		{1, 3, 3},
+		{0, 1, 1},
+		{-5, 0, 0},
+		{100, 50, 100},
+	}
+	for _, tt := range tests {
+		if got := clamp(tt.v, tt.min); got != tt.want {
+			t.Errorf("clamp(%d, %d) = %d, want %d", tt.v, tt.min, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper: sidebarWidth
+// ---------------------------------------------------------------------------
+
+func TestSidebarWidth(t *testing.T) {
+	tests := []struct {
+		total int
+		want  int
+	}{
+		{60, sidebarMinWidth},        // 60/3=20 < min → clamped to min
+		{90, sidebarMinWidth},        // 90/3=30 = min
+		{120, 40},                    // 120/3=40
+		{180, sidebarMaxWidth},       // 180/3=60 > max → clamped to max
+		{10, sidebarMinWidth},        // very small → clamped to min
+	}
+	for _, tt := range tests {
+		if got := sidebarWidth(tt.total); got != tt.want {
+			t.Errorf("sidebarWidth(%d) = %d, want %d", tt.total, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper: buildEnv
+// ---------------------------------------------------------------------------
+
+func TestBuildEnv(t *testing.T) {
+	params := map[string]string{
+		"greeting": "hello",
+		"target":   "world",
+	}
+	env := buildEnv(params)
+
+	if env["GREETING"] != "hello" {
+		t.Errorf("GREETING = %q, want hello", env["GREETING"])
+	}
+	if env["TARGET"] != "world" {
+		t.Errorf("TARGET = %q, want world", env["TARGET"])
+	}
+	if len(env) != 2 {
+		t.Errorf("len(env) = %d, want 2", len(env))
+	}
+
+	// Empty params.
+	empty := buildEnv(map[string]string{})
+	if len(empty) != 0 {
+		t.Errorf("buildEnv(empty) returned %d entries", len(empty))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper: appFooterState
+// ---------------------------------------------------------------------------
+
+func TestAppFooterState(t *testing.T) {
+	tests := []struct {
+		state viewState
+		want  footer.State
+	}{
+		{stateNormal, footer.StateNormal},
+		{stateWizard, footer.StateWizard},
+		{statePalette, footer.StatePalette},
+		{stateConfirm, footer.StateConfirm},
+		{stateHelp, footer.StateHelp},
+		{viewState(99), footer.StateNormal}, // unknown → default
+	}
+	for _, tt := range tests {
+		if got := appFooterState(tt.state); got != tt.want {
+			t.Errorf("appFooterState(%d) = %d, want %d", tt.state, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper: injectBorderBadge
+// ---------------------------------------------------------------------------
+
+func TestInjectBorderBadge(t *testing.T) {
+	// Build a box with a known top border line.
+	box := "╭──────────────────────────────────────────╮\n│ content                                  │\n╰──────────────────────────────────────────╯"
+	result := injectBorderBadge(box, "OK", nil)
+
+	// The first line should contain "OK".
+	lines := strings.Split(result, "\n")
+	if !strings.Contains(lines[0], "OK") {
+		t.Errorf("badge not found in top line: %q", lines[0])
+	}
+
+	// Content lines should be unmodified.
+	if !strings.Contains(lines[1], "content") {
+		t.Errorf("content line modified: %q", lines[1])
+	}
+}
+
+func TestInjectBorderBadge_TooNarrow(t *testing.T) {
+	// Very short box — badge shouldn't fit.
+	box := "╭──╮\n│  │\n╰──╯"
+	result := injectBorderBadge(box, "This badge is very long and should not fit", nil)
+
+	// Should return original unchanged.
+	if result != box {
+		t.Error("expected unchanged box when badge too wide")
+	}
+}
+
+func TestInjectBorderBadge_Empty(t *testing.T) {
+	result := injectBorderBadge("", "badge", nil)
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper: highlightLine
+// ---------------------------------------------------------------------------
+
+func TestHighlightLine_OutsideRange(t *testing.T) {
+	line := "hello world"
+	bounds := selectionBounds{top: 0, bottom: 10, left: 0, right: 20}
+
+	// Line index below selection start.
+	result := highlightLine(line, 0, 5, 2, 10, 4, bounds, testHighlightStyle())
+	if result != line {
+		t.Errorf("expected unchanged line for i < startY, got %q", result)
+	}
+
+	// Line index above selection end.
+	result = highlightLine(line, 5, 5, 2, 10, 4, bounds, testHighlightStyle())
+	if result != line {
+		t.Errorf("expected unchanged line for i > endY, got %q", result)
+	}
+}
+
+func TestHighlightLine_EmptyLine(t *testing.T) {
+	bounds := selectionBounds{top: 0, bottom: 10, left: 0, right: 20}
+	result := highlightLine("", 3, 0, 2, 10, 4, bounds, testHighlightStyle())
+	if result != "" {
+		t.Errorf("expected empty line unchanged, got %q", result)
+	}
+}
+
+func TestHighlightLine_WithinRange(t *testing.T) {
+	line := "hello world"
+	bounds := selectionBounds{top: 0, bottom: 10, left: 0, right: 20}
+
+	// Middle line (not start or end).
+	result := highlightLine(line, 3, 0, 2, 10, 4, bounds, testHighlightStyle())
+	if result == line {
+		t.Error("expected line to be modified within selection range")
+	}
+	// Should contain the original text (possibly styled).
+	if !strings.Contains(result, "hello world") {
+		t.Errorf("highlighted line should contain original text, got %q", result)
+	}
+}
+
+func TestHighlightLine_SingleLineSelection(t *testing.T) {
+	line := "hello world"
+	bounds := selectionBounds{top: 0, bottom: 10, left: 0, right: 20}
+
+	// startY == endY == i, selecting chars 2-7.
+	result := highlightLine(line, 3, 2, 3, 7, 3, bounds, testHighlightStyle())
+	if result == line {
+		t.Error("expected line to be modified for single-line selection")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper: applySelectionHighlight
+// ---------------------------------------------------------------------------
+
+func TestApplySelectionHighlight_NoSelection(t *testing.T) {
+	content := "line0\nline1\nline2"
+	sel := output.TextSelection{Active: true, AnchorX: 5, AnchorY: 5, FocusX: 5, FocusY: 5}
+	bounds := selectionBounds{top: 0, bottom: 2, left: 0, right: 10}
+
+	// Selection is outside content bounds — startY > endY after clamping.
+	sel.AnchorY = 10
+	sel.FocusY = 12
+	result := applySelectionHighlight(content, sel, nil, bounds)
+
+	// Should still return something (possibly unchanged).
+	if result == "" {
+		t.Error("expected non-empty result")
+	}
+}
+
+func TestApplySelectionHighlight_WithinBounds(t *testing.T) {
+	content := "aaaaaaaaaa\nbbbbbbbbbb\ncccccccccc"
+	sel := output.TextSelection{Active: true, AnchorX: 2, AnchorY: 0, FocusX: 5, FocusY: 2}
+	bounds := selectionBounds{top: 0, bottom: 2, left: 0, right: 10}
+
+	result := applySelectionHighlight(content, sel, nil, bounds)
+	if result == content {
+		t.Error("expected content to be modified by selection highlight")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Model query methods
+// ---------------------------------------------------------------------------
+
+func TestSelectedCatalog(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+
+	if m.SelectedCatalog() != nil {
+		t.Error("SelectedCatalog should be nil initially")
+	}
+
+	cat := domain.Catalog{Name: "default"}
+	rb := domain.Runbook{ID: "default.hello-world", Name: "hello-world"}
+	result, _ := m.Update(sidebar.RunbookSelectedMsg{Runbook: rb, Catalog: cat})
+	app := result.(App)
+
+	if app.SelectedCatalog() == nil {
+		t.Fatal("SelectedCatalog should be set after RunbookSelectedMsg")
+	}
+	if app.SelectedCatalog().Name != "default" {
+		t.Errorf("SelectedCatalog().Name = %q, want default", app.SelectedCatalog().Name)
+	}
+}
+
+func TestSelectedRunbook(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+
+	if m.Selected() != nil {
+		t.Error("Selected should be nil initially")
+	}
+
+	rb := domain.Runbook{ID: "default.hello-world", Name: "hello-world"}
+	cat := domain.Catalog{Name: "default"}
+	result, _ := m.Update(sidebar.RunbookSelectedMsg{Runbook: rb, Catalog: cat})
+	app := result.(App)
+
+	if app.Selected() == nil || app.Selected().ID != "default.hello-world" {
+		t.Errorf("Selected().ID = %v, want default.hello-world", app.Selected())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleKeyPress: Tab toggles focus
+// ---------------------------------------------------------------------------
+
+func TestHandleKeyPress_Tab(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateNormal
+	m.focus = focusSidebar
+
+	result, _, handled := m.handleKeyPress(tea.KeyPressMsg{Code: tea.KeyTab})
+	if !handled {
+		t.Fatal("tab should be handled")
+	}
+	app := result.(App)
+	if app.focus != focusOutput {
+		t.Errorf("focus after tab = %d, want focusOutput (%d)", app.focus, focusOutput)
+	}
+
+	// Tab again to go back.
+	result, _, handled = app.handleKeyPress(tea.KeyPressMsg{Code: tea.KeyTab})
+	if !handled {
+		t.Fatal("tab should be handled")
+	}
+	app = result.(App)
+	if app.focus != focusSidebar {
+		t.Errorf("focus after second tab = %d, want focusSidebar (%d)", app.focus, focusSidebar)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleKeyPress: ? toggles help
+// ---------------------------------------------------------------------------
+
+func TestHandleKeyPress_Help(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateNormal
+
+	result, _, handled := m.handleKeyPress(tea.KeyPressMsg{Code: '?'})
+	if !handled {
+		t.Fatal("? should be handled")
+	}
+	app := result.(App)
+	if app.state != stateHelp {
+		t.Errorf("state after ? = %d, want stateHelp (%d)", app.state, stateHelp)
+	}
+
+	// ? again to close help.
+	result, _, handled = app.handleKeyPress(tea.KeyPressMsg{Code: '?'})
+	if !handled {
+		t.Fatal("? in help state should be handled")
+	}
+	app = result.(App)
+	if app.state != stateNormal {
+		t.Errorf("state after second ? = %d, want stateNormal", app.state)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleKeyPress: Escape closes help
+// ---------------------------------------------------------------------------
+
+func TestHandleKeyPress_EscapeClosesHelp(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateHelp
+
+	result, _, handled := m.handleKeyPress(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if !handled {
+		t.Fatal("escape in help state should be handled")
+	}
+	app := result.(App)
+	if app.state != stateNormal {
+		t.Errorf("state after escape = %d, want stateNormal", app.state)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleKeyPress: unhandled key in normal state
+// ---------------------------------------------------------------------------
+
+func TestHandleKeyPress_UnhandledKey(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateNormal
+
+	_, _, handled := m.handleKeyPress(tea.KeyPressMsg{Code: 'z'})
+	if handled {
+		t.Error("'z' should not be handled in normal state")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleKeyPress: ctrl+c quits
+// ---------------------------------------------------------------------------
+
+func TestHandleKeyPress_CtrlC(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateNormal
+
+	_, cmd, handled := m.handleKeyPress(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	if !handled {
+		t.Fatal("ctrl+c should be handled")
+	}
+	if cmd == nil {
+		t.Fatal("ctrl+c should produce a quit command")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleKeyPress: ctrl+x cancels execution
+// ---------------------------------------------------------------------------
+
+func TestHandleKeyPress_CtrlX_CancelsExec(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateNormal
+
+	cancelled := false
+	m.execRunning = true
+	m.cancelExec = func() { cancelled = true }
+
+	_, _, handled := m.handleKeyPress(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	if !handled {
+		t.Fatal("ctrl+x should be handled")
+	}
+	if !cancelled {
+		t.Error("ctrl+x should call cancelExec")
+	}
+}
+
+func TestHandleKeyPress_CtrlX_NoOp_WhenNotRunning(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateNormal
+	m.execRunning = false
+
+	_, _, handled := m.handleKeyPress(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	if !handled {
+		t.Fatal("ctrl+x should be handled even when not running")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleAppMessage: executionDoneMsg
+// ---------------------------------------------------------------------------
+
+func TestHandleAppMessage_ExecutionDone(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.execRunning = true
+	m.cancelExec = func() {}
+
+	result, _, handled := m.handleAppMessage(executionDoneMsg{LogPath: "/tmp/test.log"})
+	if !handled {
+		t.Fatal("executionDoneMsg should be handled")
+	}
+	app := result.(App)
+	if app.execRunning {
+		t.Error("execRunning should be false after executionDoneMsg")
+	}
+	if app.cancelExec != nil {
+		t.Error("cancelExec should be nil after executionDoneMsg")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleAppMessage: copiedFlashMsg
+// ---------------------------------------------------------------------------
+
+func TestHandleAppMessage_CopiedFlash(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.copiedFlash = true
+
+	result, _, handled := m.handleAppMessage(copiedFlashMsg{})
+	if !handled {
+		t.Fatal("copiedFlashMsg should be handled")
+	}
+	app := result.(App)
+	if app.copiedFlash {
+		t.Error("copiedFlash should be false after copiedFlashMsg")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleAppMessage: updateAvailableMsg
+// ---------------------------------------------------------------------------
+
+func TestHandleAppMessage_UpdateAvailable(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+
+	result, _, handled := m.handleAppMessage(updateAvailableMsg{Version: "1.2.3"})
+	if !handled {
+		t.Fatal("updateAvailableMsg should be handled")
+	}
+	app := result.(App)
+	if app.updateAvailable != "1.2.3" {
+		t.Errorf("updateAvailable = %q, want 1.2.3", app.updateAvailable)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleAppMessage: confirm.CancelMsg
+// ---------------------------------------------------------------------------
+
+func TestHandleAppMessage_ConfirmCancel(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateConfirm
+	c := confirm.New(confirm.Params{
+		Runbook: domain.Runbook{ID: "test", Name: "test"},
+		Catalog: domain.Catalog{Name: "default"},
+		Width:   60,
+	})
+	m.conf = &c
+
+	result, _, handled := m.handleAppMessage(confirm.CancelMsg{})
+	if !handled {
+		t.Fatal("confirm.CancelMsg should be handled")
+	}
+	app := result.(App)
+	if app.state != stateNormal {
+		t.Errorf("state = %d, want stateNormal", app.state)
+	}
+	if app.conf != nil {
+		t.Error("conf should be nil after cancel")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleAppMessage: output.OutputLineMsg
+// ---------------------------------------------------------------------------
+
+func TestHandleAppMessage_OutputLine(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+
+	_, _, handled := m.handleAppMessage(output.OutputLineMsg{Text: "hello"})
+	if !handled {
+		t.Fatal("OutputLineMsg should be handled")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleAppMessage: unhandled message
+// ---------------------------------------------------------------------------
+
+func TestHandleAppMessage_Unhandled(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+
+	_, _, handled := m.handleAppMessage(tea.WindowSizeMsg{Width: 80, Height: 24})
+	if handled {
+		t.Error("WindowSizeMsg should not be handled by handleAppMessage")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// focusTargetFromMouse
+// ---------------------------------------------------------------------------
+
+func TestFocusTargetFromMouse(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app := result.(App)
+
+	// Non-mouse message should return false.
+	_, ok := app.focusTargetFromMouse(tea.KeyPressMsg{Code: 'a'})
+	if ok {
+		t.Error("non-mouse msg should return ok=false")
+	}
+
+	// Click in sidebar area.
+	target, ok := app.focusTargetFromMouse(tea.MouseClickMsg{X: 5, Y: 10, Button: tea.MouseLeft})
+	if !ok {
+		t.Fatal("click in sidebar should return ok=true")
+	}
+	if target != focusSidebar {
+		t.Errorf("click in sidebar target = %d, want focusSidebar", target)
+	}
+
+	// Click in output area (far right).
+	target, ok = app.focusTargetFromMouse(tea.MouseClickMsg{X: 100, Y: 10, Button: tea.MouseLeft})
+	if !ok {
+		t.Fatal("click in output area should return ok=true")
+	}
+	if target != focusOutput {
+		t.Errorf("click in output area target = %d, want focusOutput", target)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// View: zero dimensions return empty
+// ---------------------------------------------------------------------------
+
+func TestView_ZeroDimensions(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+
+	// No WindowSizeMsg sent, so width/height are 0.
+	v := m.View()
+	if v.Content != "" {
+		t.Error("View with zero dimensions should return empty content")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// View: help overlay
+// ---------------------------------------------------------------------------
+
+func TestView_HelpOverlay(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	result, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app := result.(App)
+
+	app.state = stateHelp
+	v := app.View()
+	if v.Content == "" {
+		t.Error("help overlay should produce non-empty content")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Model: NewAppWithDeps
+// ---------------------------------------------------------------------------
+
+func TestNewAppWithDeps(t *testing.T) {
+	deps := AppDeps{
+		Styles:   testutil.TestStyles(),
+		Catalogs: testCatalogs(),
+		DryRun:   true,
+	}
+	app := NewAppWithDeps(deps)
+	app.Init()
+
+	if app.Selected() != nil {
+		t.Error("new app should have no selection")
+	}
+	if app.state != stateNormal {
+		t.Error("new app should start in stateNormal")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Model: SetConfig
+// ---------------------------------------------------------------------------
+
+func TestSetConfig(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+
+	cfg := &domain.Config{}
+	m.SetConfig(cfg)
+	if m.deps.Config != cfg {
+		t.Error("SetConfig should set deps.Config")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// routeToComponent: wizard/palette/confirm states
+// ---------------------------------------------------------------------------
+
+func TestRouteToComponent_WizardNil(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateWizard
+	m.wizard = nil
+
+	// Should not panic.
+	result, _ := m.routeToComponent(tea.KeyPressMsg{Code: 'a'})
+	if result == nil {
+		t.Error("routeToComponent should return non-nil model")
+	}
+}
+
+func TestRouteToComponent_PaletteNil(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = statePalette
+	m.pal = nil
+
+	result, _ := m.routeToComponent(tea.KeyPressMsg{Code: 'a'})
+	if result == nil {
+		t.Error("routeToComponent should return non-nil model")
+	}
+}
+
+func TestRouteToComponent_ConfirmNil(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateConfirm
+	m.conf = nil
+
+	result, _ := m.routeToComponent(tea.KeyPressMsg{Code: 'a'})
+	if result == nil {
+		t.Error("routeToComponent should return non-nil model")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// routeToComponent: normal state, focus output, non-mouse
+// ---------------------------------------------------------------------------
+
+func TestRouteToComponent_FocusOutput_KeyPress(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateNormal
+	m.focus = focusOutput
+
+	result, _ := m.routeToComponent(tea.KeyPressMsg{Code: 'j'})
+	if result == nil {
+		t.Error("routeToComponent should return non-nil model")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// computeLayout: basic sanity
+// ---------------------------------------------------------------------------
+
+func TestComputeLayout(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	l := m.computeLayout()
+	if l.innerW <= 0 {
+		t.Errorf("innerW = %d, want > 0", l.innerW)
+	}
+	if l.sidebarW < sidebarMinWidth {
+		t.Errorf("sidebarW = %d, want >= %d", l.sidebarW, sidebarMinWidth)
+	}
+	if l.rightW <= 0 {
+		t.Errorf("rightW = %d, want > 0", l.rightW)
+	}
+	if l.panelRows <= 0 {
+		t.Errorf("panelRows = %d, want > 0", l.panelRows)
+	}
+	if l.outputContentH <= 0 {
+		t.Errorf("outputContentH = %d, want > 0", l.outputContentH)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sidebarBounds
+// ---------------------------------------------------------------------------
+
+func TestSidebarBounds(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	// Point inside sidebar area.
+	_, _, in := m.sidebarBounds(5, 5)
+	if !in {
+		t.Error("(5,5) should be in sidebar bounds")
+	}
+
+	// Point far right — outside sidebar.
+	_, _, in = m.sidebarBounds(100, 5)
+	if in {
+		t.Error("(100,5) should be outside sidebar bounds")
+	}
+
+	// Point above margin.
+	_, _, in = m.sidebarBounds(5, 0)
+	if in {
+		t.Error("(5,0) should be outside sidebar bounds (above margin)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// translateMouseForOutput
+// ---------------------------------------------------------------------------
+
+func TestTranslateMouseForOutput(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	// Click msg
+	click := tea.MouseClickMsg{X: 50, Y: 10, Button: tea.MouseLeft}
+	result := m.translateMouseForOutput(click)
+	translated, ok := result.(tea.MouseClickMsg)
+	if !ok {
+		t.Fatal("should return MouseClickMsg")
+	}
+	if translated.X >= 50 {
+		t.Errorf("X should be translated (reduced), got %d", translated.X)
+	}
+
+	// Release msg
+	release := tea.MouseReleaseMsg{X: 50, Y: 10}
+	rResult := m.translateMouseForOutput(release)
+	if _, ok := rResult.(tea.MouseReleaseMsg); !ok {
+		t.Fatal("should return MouseReleaseMsg")
+	}
+
+	// Motion msg
+	motion := tea.MouseMotionMsg{X: 50, Y: 10}
+	mResult := m.translateMouseForOutput(motion)
+	if _, ok := mResult.(tea.MouseMotionMsg); !ok {
+		t.Fatal("should return MouseMotionMsg")
+	}
+
+	// Wheel msg
+	wheel := tea.MouseWheelMsg{X: 50, Y: 10}
+	wResult := m.translateMouseForOutput(wheel)
+	if _, ok := wResult.(tea.MouseWheelMsg); !ok {
+		t.Fatal("should return MouseWheelMsg")
+	}
+
+	// Non-mouse passthrough
+	key := tea.KeyPressMsg{Code: tea.KeyEnter}
+	if m.translateMouseForOutput(key) != key {
+		t.Error("non-mouse msg should pass through unchanged")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// outputPaneBounds
+// ---------------------------------------------------------------------------
+
+func TestOutputPaneBounds(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	top, bottom, left, right := m.outputPaneBounds()
+	if top >= bottom {
+		t.Errorf("top (%d) should be < bottom (%d)", top, bottom)
+	}
+	if left >= right {
+		t.Errorf("left (%d) should be < right (%d)", left, right)
+	}
+	if top < 0 || left < 0 {
+		t.Error("bounds should not be negative")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// openPalette / openWizard
+// ---------------------------------------------------------------------------
+
+func TestOpenPalette(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	result, _ := m.openPalette()
+	app := result.(App)
+	if app.state != statePalette {
+		t.Error("state should be statePalette after openPalette")
+	}
+	if app.pal == nil {
+		t.Error("palette should not be nil")
+	}
+}
+
+func TestOpenWizard_NoSelection(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+	m.selected = nil
+
+	result, cmd := m.openWizard()
+	app := result.(App)
+	if app.wizard != nil {
+		t.Error("wizard should be nil when no runbook selected")
+	}
+	if cmd != nil {
+		t.Error("should return nil cmd when no selection")
+	}
+}
+
+func TestOpenWizard_WithSelection(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	rb := domain.Runbook{
+		ID:   "test.hello",
+		Name: "hello",
+		Parameters: []domain.Parameter{
+			{Name: "region", Type: domain.ParamString, Required: true, Scope: "global"},
+		},
+	}
+	cat := testCatalogs()[0].Catalog
+	m.selected = &rb
+	m.selCat = &cat
+
+	result, _ := m.openWizard()
+	app := result.(App)
+	if app.wizard == nil {
+		t.Error("wizard should be created when runbook is selected")
+	}
+	if app.state != stateWizard {
+		t.Error("state should be stateWizard")
+	}
+}
+
+func TestOpenWizard_NoParams_OpensConfirm(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	rb := domain.Runbook{
+		ID:       "test.noparam",
+		Name:     "noparam",
+		RiskLevel: domain.RiskHigh,
+	}
+	cat := testCatalogs()[0].Catalog
+	m.selected = &rb
+	m.selCat = &cat
+
+	result, _ := m.openWizard()
+	app := result.(App)
+	// No params + high risk → should open confirm dialog
+	if app.conf == nil {
+		t.Error("should open confirm for high-risk runbook with no params")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// viewConfirmOverlay / viewWizardOverlay / viewPaletteOverlay
+// ---------------------------------------------------------------------------
+
+func TestViewConfirmOverlay(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	rb := domain.Runbook{ID: "test.confirm", Name: "confirm", RiskLevel: domain.RiskHigh}
+	cat := testCatalogs()[0].Catalog
+	params := map[string]string{}
+	c := confirm.New(confirm.Params{Runbook: rb, Catalog: cat, Resolved: params, Styles: m.deps.Styles})
+	m.conf = &c
+	m.state = stateConfirm
+
+	view := m.viewConfirmOverlay()
+	if view.Content == "" {
+		t.Error("confirm overlay should produce non-empty content")
+	}
+}
+
+func TestViewPaletteOverlay(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	result, _ := m.openPalette()
+	app := result.(App)
+
+	view := app.viewPaletteOverlay()
+	if view.Content == "" {
+		t.Error("palette overlay should produce non-empty content")
+	}
+}
+
+func TestViewWizardOverlay(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	rb := domain.Runbook{
+		ID:   "test.wiz",
+		Name: "wiz",
+		Parameters: []domain.Parameter{
+			{Name: "x", Type: domain.ParamString, Required: true, Scope: "global"},
+		},
+	}
+	cat := testCatalogs()[0].Catalog
+	m.selected = &rb
+	m.selCat = &cat
+
+	result, _ := m.openWizard()
+	app := result.(App)
+
+	view := app.viewWizardOverlay()
+	if view.Content == "" {
+		t.Error("wizard overlay should produce non-empty content")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Output accessor
+// ---------------------------------------------------------------------------
+
+func TestOutput(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+
+	o := m.Output()
+	// Just ensure it returns without panic and is the zero model
+	_ = o
+}
+
+// ---------------------------------------------------------------------------
+// openConfirm with different risk levels
+// ---------------------------------------------------------------------------
+
+func TestOpenConfirm_LowRisk_SkipsConfirm(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	rb := domain.Runbook{
+		ID:        "test.low",
+		Name:      "low",
+		RiskLevel: domain.RiskLow,
+	}
+	cat := testCatalogs()[0].Catalog
+	params := map[string]string{}
+
+	result, _ := m.openConfirm(rb, cat, params)
+	app := result.(App)
+	if app.conf != nil {
+		t.Error("low risk should skip confirm dialog")
+	}
+}
+
+func TestOpenConfirm_HighRisk_ShowsConfirm(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	rb := domain.Runbook{
+		ID:        "test.high",
+		Name:      "high",
+		RiskLevel: domain.RiskHigh,
+	}
+	cat := testCatalogs()[0].Catalog
+	params := map[string]string{}
+
+	result, _ := m.openConfirm(rb, cat, params)
+	app := result.(App)
+	if app.conf == nil {
+		t.Error("high risk should show confirm dialog")
+	}
+	if app.state != stateConfirm {
+		t.Error("state should be stateConfirm")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Init with version check
+// ---------------------------------------------------------------------------
+
+func TestInit_WithVersion(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.deps.Version = "1.0.0"
+	m.deps.DopsDir = "/tmp/test"
+	cmd := m.Init()
+	if cmd == nil {
+		t.Error("Init should return commands when version is set")
+	}
+}
+
+func TestInit_WithoutVersion(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.deps.Version = ""
+	cmd := m.Init()
+	if cmd == nil {
+		t.Error("Init should still return sidebar init cmd")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveVars
+// ---------------------------------------------------------------------------
+
+func TestResolveVars_NilSelection(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.selected = nil
+	m.selCat = nil
+
+	resolved := m.resolveVars()
+	if len(resolved) != 0 {
+		t.Error("should return empty map when nothing selected")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleKeyPress: ctrl+shift+p opens palette
+// ---------------------------------------------------------------------------
+
+func TestHandleKeyPress_CtrlShiftP_OpensPalette(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	msg := tea.KeyPressMsg{Text: "ctrl+shift+p"}
+	result, _, handled := m.handleKeyPress(msg)
+	if !handled {
+		t.Error("ctrl+shift+p should be handled")
+	}
+	app := result.(App)
+	if app.state != statePalette {
+		t.Error("ctrl+shift+p should open palette")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleAppMessage: more message types
+// ---------------------------------------------------------------------------
+
+func TestHandleAppMessage_RunbookExecuteMsg(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+
+	rb := domain.Runbook{ID: "test.exec", Name: "exec",
+		Parameters: []domain.Parameter{{Name: "x", Type: domain.ParamString, Required: true, Scope: "global"}}}
+	cat := testCatalogs()[0].Catalog
+
+	msg := sidebar.RunbookExecuteMsg{Runbook: rb, Catalog: cat}
+	result, _, handled := m.handleAppMessage(msg)
+	if !handled {
+		t.Error("RunbookExecuteMsg should be handled")
+	}
+	app := result.(App)
+	if app.wizard == nil {
+		t.Error("RunbookExecuteMsg should open wizard")
+	}
+}
+
+func TestHandleAppMessage_WizardCancelMsg(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateWizard
+
+	result, _, handled := m.handleAppMessage(wizard.CancelMsg{})
+	if !handled {
+		t.Error("should be handled")
+	}
+	app := result.(App)
+	if app.state != stateNormal {
+		t.Error("should return to normal state")
+	}
+}
+
+func TestHandleAppMessage_PaletteSelectMsg(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = statePalette
+
+	result, _, handled := m.handleAppMessage(palette.PaletteSelectMsg{})
+	if !handled {
+		t.Error("should be handled")
+	}
+	app := result.(App)
+	if app.state != stateNormal {
+		t.Error("should return to normal state")
+	}
+}
+
+func TestHandleAppMessage_CopyFlashExpired(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+
+	_, _, handled := m.handleAppMessage(output.CopyFlashExpiredMsg{})
+	if !handled {
+		t.Error("should be handled")
+	}
+}
+
+func TestHandleAppMessage_CopiedRegionFlash(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.output.SetCopiedHeader(true)
+
+	result, _, handled := m.handleAppMessage(output.CopiedRegionFlashMsg{})
+	if !handled {
+		t.Error("should be handled")
+	}
+	app := result.(App)
+	_ = app
+}
+
+// ---------------------------------------------------------------------------
+// routeToComponent: more states
+// ---------------------------------------------------------------------------
+
+func TestRouteToComponent_StateNormal_SidebarFocus(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+	m.state = stateNormal
+	m.focus = focusSidebar
+
+	key := tea.KeyPressMsg{Text: "j"}
+	_, cmd := m.routeToComponent(key)
+	_ = cmd // just ensure no panic
+}
+
+func TestRouteToComponent_StateNormal_OutputFocus(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.width = 120
+	m.height = 40
+	m.state = stateNormal
+	m.focus = focusOutput
+
+	key := tea.KeyPressMsg{Text: "j"}
+	_, cmd := m.routeToComponent(key)
+	_ = cmd
+}
+
+// ---------------------------------------------------------------------------
+// themeColors: nil vs non-nil styles
+// ---------------------------------------------------------------------------
+
+func TestThemeColors_NilStyles(t *testing.T) {
+	m := NewApp(testCatalogs(), nil)
+	border, active := m.themeColors()
+	// With nil styles, should return NoColor.
+	if border != (lipgloss.NoColor{}) {
+		t.Errorf("border should be NoColor with nil styles, got %v", border)
+	}
+	if active != (lipgloss.NoColor{}) {
+		t.Errorf("active border should be NoColor with nil styles, got %v", active)
+	}
+}
+
+func TestThemeColors_WithStyles(t *testing.T) {
+	styles := testutil.TestStyles()
+	m := NewApp(testCatalogs(), styles)
+	border, active := m.themeColors()
+	// With real styles, at least one should be non-NoColor.
+	_ = border
+	_ = active
+	// Just ensure no panic; real styles may still use NoColor.
+}
+
+// ---------------------------------------------------------------------------
+// Layout: sidebarWidth and computeLayout produce consistent dimensions
+// ---------------------------------------------------------------------------
+
+func TestComputeLayout_RightPanelNarrowerThanTotal(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.width = 120
+	m.height = 40
+	l := m.computeLayout()
+
+	// Right panel (output+metadata) must be narrower than total width.
+	if l.rightW >= m.width {
+		t.Errorf("rightW=%d should be less than total width=%d", l.rightW, m.width)
+	}
+	// contentW should be less than rightW (border subtracted).
+	if l.contentW >= l.rightW {
+		t.Errorf("contentW=%d should be less than rightW=%d", l.contentW, l.rightW)
+	}
+	// sidebarW + rightW + borders + gap should approximate width.
+	if l.sidebarW <= 0 || l.rightW <= 0 {
+		t.Errorf("sidebarW=%d and rightW=%d should both be positive", l.sidebarW, l.rightW)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// focusTargetFromMouse returns correct focus pane
+// ---------------------------------------------------------------------------
+
+func TestFocusTargetFromMouse_SidebarRegion(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.width = 120
+	m.height = 40
+
+	// Click in sidebar area (far left).
+	click := tea.MouseClickMsg{X: layoutMarginLeft + 2, Y: layoutMarginTop + 2, Button: tea.MouseLeft}
+	target, ok := m.focusTargetFromMouse(click)
+	if !ok {
+		t.Fatal("should detect mouse in sidebar")
+	}
+	if target != focusSidebar {
+		t.Errorf("target = %d, want focusSidebar (%d)", target, focusSidebar)
+	}
+}
+
+func TestFocusTargetFromMouse_OutputRegion(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.width = 120
+	m.height = 40
+
+	// Click far right — should be output area.
+	click := tea.MouseClickMsg{X: 100, Y: layoutMarginTop + 2, Button: tea.MouseLeft}
+	target, ok := m.focusTargetFromMouse(click)
+	if !ok {
+		t.Fatal("should detect mouse in output")
+	}
+	if target != focusOutput {
+		t.Errorf("target = %d, want focusOutput (%d)", target, focusOutput)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func testHighlightStyle() lipgloss.Style {
+	return lipgloss.NewStyle()
+}

--- a/internal/tui/confirm/model_extra_test.go
+++ b/internal/tui/confirm/model_extra_test.go
@@ -1,0 +1,347 @@
+package confirm
+
+import (
+	"strings"
+	"testing"
+
+	"dops/internal/domain"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func newModel(risk domain.RiskLevel) Model {
+	return New(Params{
+		Runbook: domain.Runbook{
+			ID:        "infra.deploy-app",
+			Name:      "deploy-app",
+			RiskLevel: risk,
+		},
+		Catalog:  domain.Catalog{Name: "infra"},
+		Resolved: map[string]string{"env": "prod"},
+		Width:    80,
+	})
+}
+
+func TestNew_Defaults(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+
+	if m.runbook.ID != "infra.deploy-app" {
+		t.Errorf("runbook.ID = %q, want infra.deploy-app", m.runbook.ID)
+	}
+	if m.catalog.Name != "infra" {
+		t.Errorf("catalog.Name = %q, want infra", m.catalog.Name)
+	}
+	if m.risk != domain.RiskHigh {
+		t.Errorf("risk = %q, want high", m.risk)
+	}
+	if m.cursor != 1 {
+		t.Error("cursor should default to 1 (No)")
+	}
+	if m.input != "" {
+		t.Error("input should default to empty")
+	}
+	if m.width != 80 {
+		t.Errorf("width = %d, want 80", m.width)
+	}
+	if m.params["env"] != "prod" {
+		t.Errorf("params[env] = %q, want prod", m.params["env"])
+	}
+}
+
+func TestInit_ReturnsNil(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	cmd := m.Init()
+	if cmd != nil {
+		t.Error("Init() should return nil")
+	}
+}
+
+// --- High-risk toggle tests ---
+
+func TestHighRisk_LeftArrowTogglesToYes(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	if m.cursor != 1 {
+		t.Fatal("precondition: cursor should start at 1")
+	}
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	if m.cursor != 0 {
+		t.Error("left arrow should move cursor to 0 (Yes)")
+	}
+}
+
+func TestHighRisk_RightArrowTogglesToNo(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	m.cursor = 0
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	if m.cursor != 1 {
+		t.Error("right arrow should move cursor to 1 (No)")
+	}
+}
+
+func TestHighRisk_TabTogglesToYes(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.cursor != 0 {
+		t.Error("tab should move cursor to 0 (Yes)")
+	}
+}
+
+func TestHighRisk_H_TogglesToYes(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'h', Text: "h"})
+	if m.cursor != 0 {
+		t.Error("h should move cursor to 0 (Yes)")
+	}
+}
+
+func TestHighRisk_L_TogglesToNo(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	m.cursor = 0
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'l', Text: "l"})
+	if m.cursor != 1 {
+		t.Error("l should move cursor to 1 (No)")
+	}
+}
+
+func TestHighRisk_UpperY_Accepts(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'Y', Text: "Y"})
+	if cmd == nil {
+		t.Fatal("Y should produce a command")
+	}
+	if _, ok := cmd().(AcceptMsg); !ok {
+		t.Fatal("expected AcceptMsg")
+	}
+}
+
+func TestHighRisk_UpperN_Cancels(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'N', Text: "N"})
+	if cmd == nil {
+		t.Fatal("N should produce a command")
+	}
+	if _, ok := cmd().(CancelMsg); !ok {
+		t.Fatal("expected CancelMsg")
+	}
+}
+
+func TestHighRisk_EnterOnYes_Accepts(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	m.cursor = 0
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter on Yes should produce a command")
+	}
+	msg := cmd()
+	a, ok := msg.(AcceptMsg)
+	if !ok {
+		t.Fatalf("expected AcceptMsg, got %T", msg)
+	}
+	if a.Runbook.ID != "infra.deploy-app" {
+		t.Errorf("AcceptMsg.Runbook.ID = %q", a.Runbook.ID)
+	}
+	if a.Catalog.Name != "infra" {
+		t.Errorf("AcceptMsg.Catalog.Name = %q", a.Catalog.Name)
+	}
+	if a.Params["env"] != "prod" {
+		t.Errorf("AcceptMsg.Params[env] = %q", a.Params["env"])
+	}
+}
+
+func TestHighRisk_EnterOnNo_Cancels(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	// cursor defaults to 1 (No)
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter on No should produce a command")
+	}
+	if _, ok := cmd().(CancelMsg); !ok {
+		t.Fatal("expected CancelMsg")
+	}
+}
+
+// --- Critical-risk tests ---
+
+func TestCritical_Backspace(t *testing.T) {
+	m := newModel(domain.RiskCritical)
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'b', Text: "b"})
+	if m.input != "ab" {
+		t.Fatalf("input = %q, want ab", m.input)
+	}
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	if m.input != "a" {
+		t.Errorf("after backspace input = %q, want a", m.input)
+	}
+}
+
+func TestCritical_BackspaceOnEmpty(t *testing.T) {
+	m := newModel(domain.RiskCritical)
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	if m.input != "" {
+		t.Errorf("backspace on empty should keep input empty, got %q", m.input)
+	}
+}
+
+func TestCritical_EscapeCancels(t *testing.T) {
+	m := newModel(domain.RiskCritical)
+	// Type some input then escape
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("escape should produce a command")
+	}
+	if _, ok := cmd().(CancelMsg); !ok {
+		t.Fatal("expected CancelMsg")
+	}
+}
+
+func TestCritical_WhitespaceAroundIDAccepted(t *testing.T) {
+	m := newModel(domain.RiskCritical)
+	// Type " infra.deploy-app " with leading/trailing space
+	text := " infra.deploy-app "
+	for _, ch := range text {
+		m, _ = m.Update(tea.KeyPressMsg{Code: ch, Text: string(ch)})
+	}
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter with correct ID (whitespace-padded) should accept")
+	}
+	if _, ok := cmd().(AcceptMsg); !ok {
+		t.Fatal("expected AcceptMsg")
+	}
+}
+
+// --- Low/medium (default) risk tests ---
+
+func TestLowRisk_EnterImmediatelyAccepts(t *testing.T) {
+	m := newModel(domain.RiskLow)
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter on low risk should immediately accept")
+	}
+	if _, ok := cmd().(AcceptMsg); !ok {
+		t.Fatal("expected AcceptMsg")
+	}
+}
+
+func TestMediumRisk_EnterImmediatelyAccepts(t *testing.T) {
+	m := newModel(domain.RiskMedium)
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter on medium risk should immediately accept")
+	}
+	if _, ok := cmd().(AcceptMsg); !ok {
+		t.Fatal("expected AcceptMsg")
+	}
+}
+
+func TestLowRisk_EscapeCancels(t *testing.T) {
+	m := newModel(domain.RiskLow)
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("escape should produce a command")
+	}
+	if _, ok := cmd().(CancelMsg); !ok {
+		t.Fatal("expected CancelMsg")
+	}
+}
+
+// --- Non-key messages are no-ops ---
+
+func TestUpdate_IgnoresNonKeyMsg(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	_, cmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	if cmd != nil {
+		t.Error("non-key message should not produce a command")
+	}
+}
+
+// --- View tests ---
+
+func TestView_HighRisk_ContainsElements(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	v := m.View()
+
+	checks := []string{
+		"dops run infra.deploy-app",
+		"HIGH RISK",
+		"Runbook: infra.deploy-app",
+		"Confirm execution?",
+		"Yes",
+		"No",
+		"toggle",
+		"esc cancel",
+	}
+	for _, want := range checks {
+		if !strings.Contains(v, want) {
+			t.Errorf("View() missing %q", want)
+		}
+	}
+}
+
+func TestView_CriticalRisk_ContainsElements(t *testing.T) {
+	m := newModel(domain.RiskCritical)
+	// Type partial input
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	v := m.View()
+
+	checks := []string{
+		"dops run infra.deploy-app",
+		"CRITICAL RISK",
+		"Runbook: infra.deploy-app",
+		"Type the runbook ID to confirm",
+		"infra.deploy-app",
+		"> a",
+		"enter confirm",
+		"esc cancel",
+	}
+	for _, want := range checks {
+		if !strings.Contains(v, want) {
+			t.Errorf("View() missing %q", want)
+		}
+	}
+}
+
+func TestView_LowRisk_NoRiskWarning(t *testing.T) {
+	m := newModel(domain.RiskLow)
+	v := m.View()
+
+	if strings.Contains(v, "RISK") {
+		t.Error("low risk View() should not show a RISK warning")
+	}
+	if !strings.Contains(v, "dops run infra.deploy-app") {
+		t.Error("View() should show the command header")
+	}
+}
+
+// --- isConfirmed tests ---
+
+func TestIsConfirmed_HighRisk_AlwaysFalse(t *testing.T) {
+	m := newModel(domain.RiskHigh)
+	if m.isConfirmed() {
+		t.Error("high risk isConfirmed() should always return false")
+	}
+}
+
+func TestIsConfirmed_LowRisk_AlwaysTrue(t *testing.T) {
+	m := newModel(domain.RiskLow)
+	if !m.isConfirmed() {
+		t.Error("low risk isConfirmed() should return true")
+	}
+}
+
+func TestIsConfirmed_Critical_MatchesID(t *testing.T) {
+	m := newModel(domain.RiskCritical)
+	if m.isConfirmed() {
+		t.Error("empty input should not confirm")
+	}
+	m.input = "infra.deploy-app"
+	if !m.isConfirmed() {
+		t.Error("matching ID should confirm")
+	}
+	m.input = "wrong"
+	if m.isConfirmed() {
+		t.Error("wrong input should not confirm")
+	}
+}

--- a/internal/tui/help/view_test.go
+++ b/internal/tui/help/view_test.go
@@ -1,0 +1,58 @@
+package help
+
+import (
+	"dops/internal/testutil"
+	"strings"
+	"testing"
+)
+
+func TestRender_SidebarFocus(t *testing.T) {
+	styles := testutil.TestStyles()
+	result := Render(FocusSidebar, 60, styles)
+	if result == "" {
+		t.Error("Render should return non-empty content")
+	}
+	if !strings.Contains(result, "Sidebar") {
+		t.Error("should show Sidebar section when focus is sidebar")
+	}
+	if strings.Contains(result, "Output") {
+		t.Error("should NOT show Output section when focus is sidebar")
+	}
+}
+
+func TestRender_OutputFocus(t *testing.T) {
+	styles := testutil.TestStyles()
+	result := Render(FocusOutput, 60, styles)
+	if !strings.Contains(result, "Output") {
+		t.Error("should show Output section when focus is output")
+	}
+	if strings.Contains(result, "Sidebar") {
+		t.Error("should NOT show Sidebar section when focus is output")
+	}
+}
+
+func TestRender_NilStyles(t *testing.T) {
+	result := Render(FocusSidebar, 60, nil)
+	if result == "" {
+		t.Error("should render even with nil styles")
+	}
+}
+
+func TestRender_NarrowWidth(t *testing.T) {
+	styles := testutil.TestStyles()
+	result := Render(FocusSidebar, 10, styles)
+	if result == "" {
+		t.Error("should render with narrow width")
+	}
+}
+
+func TestRender_GlobalBindings(t *testing.T) {
+	styles := testutil.TestStyles()
+	result := Render(FocusSidebar, 80, styles)
+	if !strings.Contains(result, "Global") {
+		t.Error("should show Global section")
+	}
+	if !strings.Contains(result, "quit") {
+		t.Error("should show quit binding")
+	}
+}

--- a/internal/tui/metadata/view_test.go
+++ b/internal/tui/metadata/view_test.go
@@ -74,6 +74,30 @@ func TestRender_GitCatalog(t *testing.T) {
 	}
 }
 
+func TestRender_HyperlinkTarget(t *testing.T) {
+	rb := &domain.Runbook{Name: "hello-world", Version: "1.0.0", RiskLevel: domain.RiskLow}
+
+	t.Run("git catalog uses URL hyperlink", func(t *testing.T) {
+		cat := &domain.Catalog{Name: "public", URL: "https://github.com/org/repo"}
+		out := Render(RenderParams{Runbook: rb, Catalog: cat, Width: 80, Styles: testutil.TestStyles()})
+		// OSC8 hyperlink embeds the URL in the escape sequence
+		if !strings.Contains(out, "https://github.com/org/repo") {
+			t.Error("git catalog should embed URL as hyperlink target")
+		}
+		if strings.Contains(out, "file://") {
+			t.Error("git catalog should NOT use file:// hyperlink")
+		}
+	})
+
+	t.Run("local catalog uses file hyperlink", func(t *testing.T) {
+		cat := &domain.Catalog{Name: "default", Path: "~/.dops/catalogs/default"}
+		out := Render(RenderParams{Runbook: rb, Catalog: cat, Width: 80, Styles: testutil.TestStyles()})
+		if !strings.Contains(out, "file://") {
+			t.Error("local catalog should use file:// hyperlink")
+		}
+	})
+}
+
 func TestRender_CopiedFlash(t *testing.T) {
 	rb := &domain.Runbook{
 		Name:      "hello-world",

--- a/internal/tui/output/model_extra_test.go
+++ b/internal/tui/output/model_extra_test.go
@@ -1,0 +1,383 @@
+package output
+
+import (
+	"dops/internal/testutil"
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+func TestSetSize(t *testing.T) {
+	m := New(60, 20, testutil.TestStyles())
+	m.SetSize(100, 50)
+	// No panic, just ensure it sets internal state.
+	if m.width != 100 {
+		t.Errorf("width = %d, want 100", m.width)
+	}
+	if m.height != 50 {
+		t.Errorf("height = %d, want 50", m.height)
+	}
+}
+
+func TestSetFocused(t *testing.T) {
+	m := New(60, 20, testutil.TestStyles())
+	m.SetFocused(true)
+	if !m.focused {
+		t.Error("should be focused")
+	}
+	m.SetFocused(false)
+	if m.focused {
+		t.Error("should not be focused")
+	}
+}
+
+func TestCopyFlash(t *testing.T) {
+	m := New(60, 20, testutil.TestStyles())
+	if m.CopyFlash() {
+		t.Error("should not flash initially")
+	}
+	m.SetCopyFlash(true)
+	if !m.CopyFlash() {
+		t.Error("should flash after SetCopyFlash(true)")
+	}
+	m.SetCopyFlash(false)
+	if m.CopyFlash() {
+		t.Error("should not flash after SetCopyFlash(false)")
+	}
+}
+
+func TestTryCopy(t *testing.T) {
+	m := New(60, 20, testutil.TestStyles())
+	if !m.TryCopy() {
+		t.Error("first TryCopy should succeed")
+	}
+	if !m.CopyFlash() {
+		t.Error("TryCopy should enable flash")
+	}
+	if m.TryCopy() {
+		t.Error("second TryCopy should fail (lock held)")
+	}
+	// Release lock
+	m.SetCopyFlash(false)
+	if !m.TryCopy() {
+		t.Error("TryCopy after release should succeed")
+	}
+}
+
+func TestTryLock(t *testing.T) {
+	m := New(60, 20, testutil.TestStyles())
+	if !m.TryLock() {
+		t.Error("first TryLock should succeed")
+	}
+	if m.CopyFlash() {
+		t.Error("TryLock should NOT enable flash")
+	}
+	if m.TryLock() {
+		t.Error("second TryLock should fail (lock held)")
+	}
+}
+
+func TestSelection(t *testing.T) {
+	m := New(60, 20, testutil.TestStyles())
+	sel := m.Selection()
+	if sel.Active {
+		t.Error("selection should not be active initially")
+	}
+}
+
+func TestSetCopiedHeaderFooter(t *testing.T) {
+	m := New(60, 20, testutil.TestStyles())
+	m.SetCopiedHeader(true)
+	if !m.copiedHeader {
+		t.Error("copiedHeader should be true")
+	}
+	m.SetCopiedFooter(true)
+	if !m.copiedFooter {
+		t.Error("copiedFooter should be true")
+	}
+}
+
+func TestClear(t *testing.T) {
+	m := New(60, 20, testutil.TestStyles())
+	m.SetCommand("test")
+	m, _ = m.Update(OutputLineMsg{Text: "line1"})
+	m.Clear()
+	if m.Command() != "" {
+		t.Error("command should be empty after clear")
+	}
+	if len(m.Lines()) != 0 {
+		t.Error("lines should be empty after clear")
+	}
+}
+
+func TestHasSession(t *testing.T) {
+	m := New(60, 20, testutil.TestStyles())
+	if m.HasSession() {
+		t.Error("should not have session initially")
+	}
+	m.SetCommand("test")
+	if !m.HasSession() {
+		t.Error("should have session after SetCommand")
+	}
+}
+
+func TestTruncateLine(t *testing.T) {
+	m := New(60, 20, testutil.TestStyles())
+	// truncateLine needs a line and maxWidth
+	// Test with a short line that doesn't need truncation.
+	result := m.truncateLine("hello", 10)
+	if result != "hello" {
+		t.Errorf("short line should not be truncated, got %q", result)
+	}
+
+	// Test with a line that needs truncation.
+	long := "this is a very long line that should be truncated"
+	result = m.truncateLine(long, 10)
+	if len(result) > 15 { // some slack for ANSI
+		t.Errorf("long line should be truncated, got len %d", len(result))
+	}
+}
+
+func TestRenderHeader_WithCommand(t *testing.T) {
+	m := New(80, 30, testutil.TestStyles())
+	m.SetCommand("dops run default.hello-world")
+
+	c := m.resolveColors()
+	header := m.renderHeader(70, c)
+	if header == "" {
+		t.Error("header should not be empty when command is set")
+	}
+}
+
+func TestRenderHeader_WithCopiedBadge(t *testing.T) {
+	m := New(80, 30, testutil.TestStyles())
+	m.SetCommand("dops run test")
+	m.SetCopiedHeader(true)
+
+	c := m.resolveColors()
+	header := m.renderHeader(70, c)
+	if header == "" {
+		t.Error("header should not be empty")
+	}
+}
+
+func TestRenderHeader_WithDoneBadge(t *testing.T) {
+	m := New(80, 30, testutil.TestStyles())
+	m.SetCommand("dops run test")
+	m, _ = m.Update(ExecutionDoneMsg{LogPath: "/tmp/test.log"})
+
+	c := m.resolveColors()
+	header := m.renderHeader(70, c)
+	if header == "" {
+		t.Error("header should not be empty after execution done")
+	}
+}
+
+func TestVisibleLineTexts(t *testing.T) {
+	m := New(80, 30, testutil.TestStyles())
+	m, _ = m.Update(OutputLineMsg{Text: "line1"})
+	m, _ = m.Update(OutputLineMsg{Text: "line2"})
+	m, _ = m.Update(OutputLineMsg{Text: "line3"})
+
+	texts := m.visibleLineTexts()
+	// visibleLineTexts returns viewport-visible lines, which may include empty padding
+	if len(texts) == 0 {
+		t.Error("should have visible lines")
+	}
+}
+
+func TestUpdate_WindowResize(t *testing.T) {
+	m := New(60, 20, testutil.TestStyles())
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+	// Just ensure no panic
+}
+
+func TestUpdate_MouseWheel(t *testing.T) {
+	m := New(60, 20, testutil.TestStyles())
+	m.SetCommand("test")
+	m, _ = m.Update(OutputLineMsg{Text: "line"})
+	// Send mouse wheel messages (no panic)
+	m, _ = m.Update(tea.MouseWheelMsg{X: 10, Y: 5})
+	_ = m
+}
+
+func TestHandleClick_HeaderRegion(t *testing.T) {
+	m := New(80, 30, testutil.TestStyles())
+	m.SetCommand("dops run test")
+
+	// Click at very top of output area — should be header
+	copyText, region := m.HandleClick(10, 0, 70, 25)
+	// May or may not match — just ensure no panic
+	_ = copyText
+	_ = region
+}
+
+func TestHandleClick_FooterRegion(t *testing.T) {
+	m := New(80, 30, testutil.TestStyles())
+	m.SetCommand("dops run test")
+	m, _ = m.Update(ExecutionDoneMsg{LogPath: "/tmp/test.log"})
+
+	// Click at bottom of output area — should be footer
+	_, region := m.HandleClick(10, 24, 70, 25)
+	_ = region
+}
+
+func TestView_ContentWidthRespectsPadding(t *testing.T) {
+	// View() uses contentWidth = max(1, m.width - padX*2) where padX=1.
+	// If the negation is inverted (width+2 instead of width-2), the rendered
+	// output would exceed the model's width.
+	m := New(40, 20, testutil.TestStyles())
+	m.SetCommand("echo hello")
+	m, _ = m.Update(OutputLineMsg{Text: "test output line"})
+
+	view := m.View()
+	lines := strings.Split(view, "\n")
+	for i, line := range lines {
+		w := lipgloss.Width(line)
+		if w > 40 {
+			t.Errorf("line %d width %d exceeds model width 40: %q", i, w, line)
+		}
+	}
+}
+
+func TestRenderHeader_LongCommandWraps(t *testing.T) {
+	m := New(80, 30, testutil.TestStyles())
+	// Command with --param boundaries that is wider than contentWidth.
+	longCmd := "dops run default.deploy --param region=us-east-1 --param env=staging --param replicas=3 --param dry_run=true"
+	m.SetCommand(longCmd)
+
+	c := m.resolveColors()
+	header := m.renderHeader(40, c)
+
+	// Header should contain at least 2 lines (wrapped at --param boundary).
+	lines := strings.Split(header, "\n")
+	if len(lines) < 2 {
+		t.Errorf("long command should wrap, got %d lines", len(lines))
+	}
+	// Each line should respect the width (accounting for ANSI codes).
+	for i, line := range lines {
+		w := lipgloss.Width(line)
+		if w > 42 { // 40 + 2 for "$ " prefix
+			t.Errorf("header line %d width %d exceeds content width: %q", i, w, line)
+		}
+	}
+}
+
+func TestRenderSearchBar_Navigating_NoMatches(t *testing.T) {
+	m := New(80, 30, testutil.TestStyles())
+	m.navigating = true
+	m.matchCount = 0
+	m.searchQuery = "test"
+
+	contentStyle := lipgloss.NewStyle()
+	successStyle := lipgloss.NewStyle()
+	result := m.renderSearchBar(60, contentStyle, successStyle)
+
+	// With matchCount=0, no search bar should be rendered.
+	if result != nil {
+		t.Errorf("navigating with matchCount=0 should return nil, got %d lines", len(result))
+	}
+}
+
+func TestRenderSearchBar_Navigating_WithMatches(t *testing.T) {
+	m := New(80, 30, testutil.TestStyles())
+	m.navigating = true
+	m.matchCount = 3
+	m.matchIndex = 1
+	m.searchQuery = "error"
+
+	contentStyle := lipgloss.NewStyle()
+	successStyle := lipgloss.NewStyle()
+	result := m.renderSearchBar(60, contentStyle, successStyle)
+
+	if result == nil || len(result) != 2 {
+		t.Fatalf("navigating with matches should return 2 lines, got %v", result)
+	}
+	if !strings.Contains(result[0], "[2/3]") {
+		t.Errorf("search bar should show match position [2/3], got %q", result[0])
+	}
+}
+
+func TestRenderSearchBar_Searching(t *testing.T) {
+	m := New(80, 30, testutil.TestStyles())
+	m.searching = true
+	m.searchQuery = "foo"
+
+	contentStyle := lipgloss.NewStyle()
+	result := m.renderSearchBar(60, contentStyle, contentStyle)
+
+	if result == nil || len(result) != 2 {
+		t.Fatalf("searching should return 2 lines, got %v", result)
+	}
+	if !strings.Contains(result[0], "Search: foo") {
+		t.Errorf("search bar should show query, got %q", result[0])
+	}
+}
+
+func TestRenderScrollbar_NoScroll(t *testing.T) {
+	// When total lines <= visibleH, scrollbar should be plain track.
+	m := New(80, 30, testutil.TestStyles())
+	for i := 0; i < 5; i++ {
+		m, _ = m.Update(OutputLineMsg{Text: fmt.Sprintf("line-%d", i)})
+	}
+
+	p := scrollbarParams{
+		contentH:   10,
+		yOffset:    0,
+		visibleH:   5, // exactly equal to total lines
+		trackStyle: lipgloss.NewStyle(),
+		thumbStyle: lipgloss.NewStyle(),
+	}
+	bar := m.renderScrollbar(p)
+	lines := strings.Split(bar, "\n")
+	if len(lines) != 10 {
+		t.Errorf("scrollbar should have %d lines, got %d", p.contentH, len(lines))
+	}
+}
+
+func TestRenderScrollbar_WithScroll(t *testing.T) {
+	// When total lines > visibleH, scrollbar should show thumb.
+	m := New(80, 30, testutil.TestStyles())
+	for i := 0; i < 50; i++ {
+		m, _ = m.Update(OutputLineMsg{Text: fmt.Sprintf("line-%d", i)})
+	}
+
+	p := scrollbarParams{
+		contentH:   20,
+		yOffset:    10,
+		visibleH:   20,
+		trackStyle: lipgloss.NewStyle(),
+		thumbStyle: lipgloss.NewStyle().Background(lipgloss.Color("7")),
+	}
+	bar := m.renderScrollbar(p)
+	if bar == "" {
+		t.Error("scrollbar should not be empty with scrollable content")
+	}
+}
+
+func TestRenderFooter_WithLogPath(t *testing.T) {
+	m := New(80, 30, testutil.TestStyles())
+	m.logPath = "/tmp/dops/test.log"
+
+	c := m.resolveColors()
+	footer := m.renderFooterSection(60, c)
+	if !strings.Contains(footer, "test.log") {
+		t.Error("footer should contain log path")
+	}
+}
+
+func TestRenderFooter_TruncatesLongPath(t *testing.T) {
+	m := New(80, 30, testutil.TestStyles())
+	m.logPath = "/very/long/path/to/some/deeply/nested/directory/structure/logs/dops/default/hello-world/20260331-120000.log"
+
+	c := m.resolveColors()
+	footer := m.renderFooterSection(40, c)
+	// Should truncate with ellipsis rather than exceed width.
+	w := lipgloss.Width(footer)
+	if w > 42 { // some tolerance for ANSI
+		t.Errorf("footer width %d exceeds content width 40", w)
+	}
+}

--- a/internal/tui/sidebar/model_test.go
+++ b/internal/tui/sidebar/model_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
 )
 
 func testCatalogs() []catalog.CatalogWithRunbooks {
@@ -366,5 +367,85 @@ func TestSidebar_ViewShowsCollapseIndicator(t *testing.T) {
 	view = m.View()
 	if !strings.Contains(view, "▶") {
 		t.Error("collapsed catalog should show ▶")
+	}
+}
+
+func TestRenderEntry_HoverVsUnselected(t *testing.T) {
+	m := New(testCatalogs(), 20, testutil.TestStyles())
+
+	e := entry{
+		runbook: domain.Runbook{Name: "test-runbook"},
+		catalog: domain.Catalog{Name: "default"},
+	}
+	s := entryStyles{
+		cursor:         lipgloss.NewStyle().Bold(true),
+		hover:          lipgloss.NewStyle().Underline(true),
+		header:         lipgloss.NewStyle(),
+		headerSelected: lipgloss.NewStyle(),
+		selected:       lipgloss.NewStyle().Bold(true),
+		unselected:     lipgloss.NewStyle(),
+	}
+
+	hovered := m.renderEntry(e, s, false, true, false, false)
+	normal := m.renderEntry(e, s, false, false, false, false)
+
+	if hovered == normal {
+		t.Error("hovered entry should be styled differently from unselected entry")
+	}
+}
+
+func TestRenderEntry_SelectedTakesPriority(t *testing.T) {
+	m := New(testCatalogs(), 20, testutil.TestStyles())
+
+	e := entry{
+		runbook: domain.Runbook{Name: "test-runbook"},
+		catalog: domain.Catalog{Name: "default"},
+	}
+	s := entryStyles{
+		cursor:         lipgloss.NewStyle().Bold(true),
+		hover:          lipgloss.NewStyle().Underline(true),
+		header:         lipgloss.NewStyle(),
+		headerSelected: lipgloss.NewStyle(),
+		selected:       lipgloss.NewStyle().Bold(true),
+		unselected:     lipgloss.NewStyle(),
+	}
+
+	// isCursor=true, isHovered=true — selected should win.
+	selectedHovered := m.renderEntry(e, s, true, true, false, false)
+	selectedOnly := m.renderEntry(e, s, true, false, false, false)
+
+	if selectedHovered != selectedOnly {
+		t.Errorf("selected should take priority over hover\nselected+hover: %q\nselected only:  %q", selectedHovered, selectedOnly)
+	}
+}
+
+func TestBuildLines_HoverAppliesCorrectly(t *testing.T) {
+	m := New(testCatalogs(), 20, testutil.TestStyles())
+
+	// Cursor on hello-world (vis index 1), hover on rotate-tls (vis index 2).
+	m.hoverIdx = 2
+
+	vis := m.visible()
+	lines := m.buildLines(vis)
+	if len(lines) < 5 {
+		t.Fatalf("expected at least 5 lines, got %d", len(lines))
+	}
+
+	// Build another version without hover.
+	m2 := New(testCatalogs(), 20, testutil.TestStyles())
+	m2.hoverIdx = -1
+
+	vis2 := m2.visible()
+	lines2 := m2.buildLines(vis2)
+
+	// The hovered entry (rotate-tls, lines[2]) should be different from the
+	// non-hovered version (lines2[2]).
+	if lines[2] == lines2[2] {
+		t.Error("hovered rotate-tls should be styled differently from non-hovered rotate-tls")
+	}
+
+	// The non-hovered entries should be identical.
+	if lines[4] != lines2[4] {
+		t.Error("non-hovered drain-node should be identical in both versions")
 	}
 }

--- a/internal/tui/wizard/model_extra_test.go
+++ b/internal/tui/wizard/model_extra_test.go
@@ -1,0 +1,1502 @@
+package wizard
+
+import (
+	"dops/internal/domain"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/bubbles/v2/textinput"
+)
+
+// ---------- helpers ----------
+
+func stringParam(name string, required bool, scope string) domain.Parameter {
+	return domain.Parameter{Name: name, Type: domain.ParamString, Required: required, Scope: scope}
+}
+
+// localStringParam creates a string param with "local" scope (no save prompt).
+func localStringParam(name string, required bool) domain.Parameter {
+	return domain.Parameter{Name: name, Type: domain.ParamString, Required: required, Scope: "local"}
+}
+
+func integerParam(name string) domain.Parameter {
+	return domain.Parameter{Name: name, Type: domain.ParamInteger, Required: true, Scope: "local"}
+}
+
+func numberParam(name string) domain.Parameter {
+	return domain.Parameter{Name: name, Type: domain.ParamNumber, Required: true, Scope: "local"}
+}
+
+func floatParam(name string) domain.Parameter {
+	return domain.Parameter{Name: name, Type: domain.ParamFloat, Required: true, Scope: "local"}
+}
+
+func selectParam(name string, opts []string) domain.Parameter {
+	return domain.Parameter{Name: name, Type: domain.ParamSelect, Required: true, Scope: "local", Options: opts}
+}
+
+func multiSelectParam(name string, opts []string) domain.Parameter {
+	return domain.Parameter{Name: name, Type: domain.ParamMultiSelect, Required: false, Scope: "local", Options: opts}
+}
+
+func boolParam(name string) domain.Parameter {
+	return domain.Parameter{Name: name, Type: domain.ParamBoolean, Required: false, Scope: "local"}
+}
+
+func secretParam(name string) domain.Parameter {
+	return domain.Parameter{Name: name, Type: domain.ParamString, Required: true, Scope: "global", Secret: true}
+}
+
+func defaultCatalog() domain.Catalog {
+	return domain.Catalog{Name: "default"}
+}
+
+func keyMsg(code rune) tea.Msg {
+	return tea.KeyPressMsg{Code: code}
+}
+
+func textKeyMsg(text string) tea.Msg {
+	return tea.KeyPressMsg{Text: text}
+}
+
+func enterMsg() tea.Msg { return keyMsg(tea.KeyEnter) }
+func escMsg() tea.Msg   { return keyMsg(tea.KeyEscape) }
+
+// ---------- Init tests ----------
+
+func TestInit_EmptyParams(t *testing.T) {
+	rb := domain.Runbook{ID: "test.empty", Name: "empty"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	cmd := m.Init()
+	if cmd != nil {
+		t.Error("Init should return nil when there are no parameters")
+	}
+}
+
+func TestInit_NonePrefilled_TextInput(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.one",
+		Name:       "one",
+		Parameters: []domain.Parameter{stringParam("name", true, "global")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	cmd := m.Init()
+	if cmd == nil {
+		t.Error("Init should return a focus command for text input field")
+	}
+}
+
+func TestInit_NonePrefilled_SelectField(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.sel",
+		Name:       "sel",
+		Parameters: []domain.Parameter{selectParam("env", []string{"dev", "prod"})},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	cmd := m.Init()
+	if cmd != nil {
+		t.Error("Init should return nil for a select field (no text input to focus)")
+	}
+}
+
+func TestInit_AllPrefilled_SubmitsImmediately(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.full",
+		Name:       "full",
+		Parameters: []domain.Parameter{stringParam("a", true, "global")},
+	}
+	resolved := map[string]string{"a": "val"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved})
+
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatal("Init should return a submit command when all fields are prefilled")
+	}
+	msg := cmd()
+	if _, ok := msg.(SubmitMsg); !ok {
+		t.Errorf("expected SubmitMsg, got %T", msg)
+	}
+}
+
+func TestInit_BooleanField(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.bool",
+		Name:       "bool",
+		Parameters: []domain.Parameter{boolParam("flag")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	cmd := m.Init()
+	if cmd != nil {
+		t.Error("Init should return nil for a boolean field")
+	}
+}
+
+// ---------- Update: escape cancels ----------
+
+func TestUpdate_Escape(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.esc",
+		Name:       "esc",
+		Parameters: []domain.Parameter{stringParam("x", true, "global")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m, cmd := m.Update(escMsg())
+	if cmd == nil {
+		t.Fatal("escape should produce a cancel command")
+	}
+	msg := cmd()
+	if _, ok := msg.(CancelMsg); !ok {
+		t.Errorf("expected CancelMsg, got %T", msg)
+	}
+}
+
+// ---------- Update: empty params ----------
+
+func TestUpdate_EmptyParams(t *testing.T) {
+	rb := domain.Runbook{ID: "test.empty", Name: "empty"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m, cmd := m.Update(enterMsg())
+	if cmd != nil {
+		t.Error("update on empty params should return nil cmd")
+	}
+}
+
+// ---------- Update: text input enter submits value ----------
+
+func TestUpdate_TextInput_EnterAdvances(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.txt",
+		Name: "txt",
+		Parameters: []domain.Parameter{
+			localStringParam("first", true),
+			localStringParam("second", true),
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Type a value into the text input.
+	m.input.SetValue("hello")
+	m, _ = m.Update(enterMsg())
+
+	if m.values["first"] != "hello" {
+		t.Errorf("expected first=hello, got %q", m.values["first"])
+	}
+	if m.current != 1 {
+		t.Errorf("expected to advance to field 1, got %d", m.current)
+	}
+}
+
+func TestUpdate_TextInput_RequiredEmpty(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.req",
+		Name:       "req",
+		Parameters: []domain.Parameter{stringParam("x", true, "global")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Leave empty, press enter.
+	m, _ = m.Update(enterMsg())
+	if m.err != "required field" {
+		t.Errorf("expected 'required field' error, got %q", m.err)
+	}
+	if m.current != 0 {
+		t.Error("should not advance past required empty field")
+	}
+}
+
+func TestUpdate_TextInput_OptionalEmpty(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.opt",
+		Name:       "opt",
+		Parameters: []domain.Parameter{localStringParam("x", false)},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m, cmd := m.Update(enterMsg())
+	if m.err != "" {
+		t.Errorf("optional empty field should not error, got %q", m.err)
+	}
+	// Should produce a submit since it's the last field.
+	if cmd == nil {
+		t.Fatal("should produce submit cmd for last field")
+	}
+	msg := cmd()
+	if _, ok := msg.(SubmitMsg); !ok {
+		t.Errorf("expected SubmitMsg, got %T", msg)
+	}
+}
+
+// ---------- Update: integer validation ----------
+
+func TestUpdate_IntegerParam_Invalid(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.int",
+		Name:       "int",
+		Parameters: []domain.Parameter{integerParam("count")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("abc")
+
+	m, _ = m.Update(enterMsg())
+	if m.err != "must be an integer" {
+		t.Errorf("expected integer error, got %q", m.err)
+	}
+}
+
+func TestUpdate_IntegerParam_Valid(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.int",
+		Name:       "int",
+		Parameters: []domain.Parameter{integerParam("count")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("42")
+
+	m, cmd := m.Update(enterMsg())
+	if m.err != "" {
+		t.Errorf("valid integer should not error, got %q", m.err)
+	}
+	if m.values["count"] != "42" {
+		t.Errorf("expected count=42, got %q", m.values["count"])
+	}
+	if cmd == nil {
+		t.Fatal("should submit after last field")
+	}
+}
+
+func TestUpdate_IntegerParam_Negative(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.int",
+		Name:       "int",
+		Parameters: []domain.Parameter{integerParam("offset")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("-5")
+
+	m, _ = m.Update(enterMsg())
+	if m.err != "" {
+		t.Errorf("negative integer should be valid for ParamInteger, got %q", m.err)
+	}
+	if m.values["offset"] != "-5" {
+		t.Errorf("expected offset=-5, got %q", m.values["offset"])
+	}
+}
+
+// ---------- Update: number validation (non-negative) ----------
+
+func TestUpdate_NumberParam_Negative(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.num",
+		Name:       "num",
+		Parameters: []domain.Parameter{numberParam("port")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("-1")
+
+	m, _ = m.Update(enterMsg())
+	if m.err != "must be a non-negative number" {
+		t.Errorf("expected non-negative error, got %q", m.err)
+	}
+}
+
+func TestUpdate_NumberParam_NotANumber(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.num",
+		Name:       "num",
+		Parameters: []domain.Parameter{numberParam("port")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("abc")
+
+	m, _ = m.Update(enterMsg())
+	if m.err != "must be a number" {
+		t.Errorf("expected 'must be a number' error, got %q", m.err)
+	}
+}
+
+func TestUpdate_NumberParam_Zero(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.num",
+		Name:       "num",
+		Parameters: []domain.Parameter{numberParam("count")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("0")
+
+	m, _ = m.Update(enterMsg())
+	if m.err != "" {
+		t.Errorf("zero should be valid for ParamNumber, got %q", m.err)
+	}
+	if m.values["count"] != "0" {
+		t.Errorf("expected count=0, got %q", m.values["count"])
+	}
+}
+
+// ---------- Update: float validation ----------
+
+func TestUpdate_FloatParam_Invalid(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.float",
+		Name:       "float",
+		Parameters: []domain.Parameter{floatParam("ratio")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("not-a-float")
+
+	m, _ = m.Update(enterMsg())
+	if m.err != "must be a decimal number" {
+		t.Errorf("expected float error, got %q", m.err)
+	}
+}
+
+func TestUpdate_FloatParam_Valid(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.float",
+		Name:       "float",
+		Parameters: []domain.Parameter{floatParam("ratio")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("3.14")
+
+	m, _ = m.Update(enterMsg())
+	if m.err != "" {
+		t.Errorf("valid float should not error, got %q", m.err)
+	}
+	if m.values["ratio"] != "3.14" {
+		t.Errorf("expected ratio=3.14, got %q", m.values["ratio"])
+	}
+}
+
+// ---------- Update: select field ----------
+
+func TestUpdate_Select_NavigateAndChoose(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.sel",
+		Name:       "sel",
+		Parameters: []domain.Parameter{selectParam("env", []string{"dev", "staging", "prod"})},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Move down twice (to "prod").
+	m, _ = m.Update(keyMsg(tea.KeyDown))
+	m, _ = m.Update(keyMsg(tea.KeyDown))
+	if m.cursor != 2 {
+		t.Errorf("cursor should be 2, got %d", m.cursor)
+	}
+
+	// Move up once (to "staging").
+	m, _ = m.Update(keyMsg(tea.KeyUp))
+	if m.cursor != 1 {
+		t.Errorf("cursor should be 1, got %d", m.cursor)
+	}
+
+	// Press enter to select "staging".
+	m, cmd := m.Update(enterMsg())
+	if m.values["env"] != "staging" {
+		t.Errorf("expected env=staging, got %q", m.values["env"])
+	}
+	if cmd == nil {
+		t.Fatal("should submit after last field")
+	}
+}
+
+func TestUpdate_Select_JKNavigation(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.sel",
+		Name:       "sel",
+		Parameters: []domain.Parameter{selectParam("env", []string{"dev", "staging", "prod"})},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m, _ = m.Update(textKeyMsg("j"))
+	if m.cursor != 1 {
+		t.Errorf("j should move cursor down, got %d", m.cursor)
+	}
+	m, _ = m.Update(textKeyMsg("k"))
+	if m.cursor != 0 {
+		t.Errorf("k should move cursor up, got %d", m.cursor)
+	}
+}
+
+func TestUpdate_Select_CursorBounds(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.sel",
+		Name:       "sel",
+		Parameters: []domain.Parameter{selectParam("env", []string{"dev", "prod"})},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Move up at top should stay at 0.
+	m, _ = m.Update(keyMsg(tea.KeyUp))
+	if m.cursor != 0 {
+		t.Errorf("cursor should stay at 0, got %d", m.cursor)
+	}
+
+	// Move to bottom and try to go past.
+	m, _ = m.Update(keyMsg(tea.KeyDown))
+	m, _ = m.Update(keyMsg(tea.KeyDown))
+	if m.cursor != 1 {
+		t.Errorf("cursor should be clamped at 1, got %d", m.cursor)
+	}
+}
+
+// ---------- Update: multi-select field ----------
+
+func TestUpdate_MultiSelect_ToggleAndSubmit(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.ms",
+		Name:       "ms",
+		Parameters: []domain.Parameter{multiSelectParam("tags", []string{"alpha", "beta", "gamma"})},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Toggle first option (space).
+	m, _ = m.Update(textKeyMsg(" "))
+	if !m.checked[0] {
+		t.Error("first option should be checked")
+	}
+
+	// Move down and toggle second.
+	m, _ = m.Update(keyMsg(tea.KeyDown))
+	m, _ = m.Update(textKeyMsg(" "))
+	if !m.checked[1] {
+		t.Error("second option should be checked")
+	}
+
+	// Untoggle first.
+	m, _ = m.Update(keyMsg(tea.KeyUp))
+	m, _ = m.Update(textKeyMsg(" "))
+	if m.checked[0] {
+		t.Error("first option should be unchecked after second toggle")
+	}
+
+	// Submit — only "beta" is checked.
+	m, cmd := m.Update(enterMsg())
+	if m.values["tags"] != "beta" {
+		t.Errorf("expected tags=beta, got %q", m.values["tags"])
+	}
+	if cmd == nil {
+		t.Fatal("should submit after last field")
+	}
+}
+
+func TestUpdate_MultiSelect_NoneChecked(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.ms",
+		Name:       "ms",
+		Parameters: []domain.Parameter{multiSelectParam("tags", []string{"a", "b"})},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Submit without toggling anything.
+	m, cmd := m.Update(enterMsg())
+	if m.values["tags"] != "" {
+		t.Errorf("expected empty tags, got %q", m.values["tags"])
+	}
+	if cmd == nil {
+		t.Fatal("should submit")
+	}
+}
+
+// ---------- Update: boolean field ----------
+
+func TestUpdate_Boolean_ToggleAndEnter(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.bool",
+		Name:       "bool",
+		Parameters: []domain.Parameter{boolParam("flag")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Default cursor is 1 (No).
+	if m.cursor != 1 {
+		t.Errorf("boolean default cursor should be 1 (No), got %d", m.cursor)
+	}
+
+	// Press left to move to Yes.
+	m, _ = m.Update(keyMsg(tea.KeyLeft))
+	if m.cursor != 0 {
+		t.Errorf("cursor should be 0 (Yes), got %d", m.cursor)
+	}
+
+	// Enter confirms Yes.
+	m, cmd := m.Update(enterMsg())
+	if m.values["flag"] != "true" {
+		t.Errorf("expected flag=true, got %q", m.values["flag"])
+	}
+	if cmd == nil {
+		t.Fatal("should submit after last field")
+	}
+}
+
+func TestUpdate_Boolean_YKey(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.bool",
+		Name:       "bool",
+		Parameters: []domain.Parameter{boolParam("flag")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m, cmd := m.Update(textKeyMsg("y"))
+	if m.values["flag"] != "true" {
+		t.Errorf("y key should set true, got %q", m.values["flag"])
+	}
+	if cmd == nil {
+		t.Fatal("should submit")
+	}
+}
+
+func TestUpdate_Boolean_NKey(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.bool",
+		Name:       "bool",
+		Parameters: []domain.Parameter{boolParam("flag")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m, cmd := m.Update(textKeyMsg("n"))
+	if m.values["flag"] != "false" {
+		t.Errorf("n key should set false, got %q", m.values["flag"])
+	}
+	if cmd == nil {
+		t.Fatal("should submit")
+	}
+}
+
+func TestUpdate_Boolean_HLNavigation(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.bool",
+		Name:       "bool",
+		Parameters: []domain.Parameter{boolParam("flag")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// h → Yes (cursor 0).
+	m, _ = m.Update(textKeyMsg("h"))
+	if m.cursor != 0 {
+		t.Errorf("h should set cursor to 0, got %d", m.cursor)
+	}
+
+	// l → No (cursor 1).
+	m, _ = m.Update(textKeyMsg("l"))
+	if m.cursor != 1 {
+		t.Errorf("l should set cursor to 1, got %d", m.cursor)
+	}
+}
+
+func TestUpdate_Boolean_TabMovesToYes(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.bool",
+		Name:       "bool",
+		Parameters: []domain.Parameter{boolParam("flag")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m, _ = m.Update(keyMsg(tea.KeyTab))
+	if m.cursor != 0 {
+		t.Errorf("tab should set cursor to 0 (Yes), got %d", m.cursor)
+	}
+}
+
+// ---------- Update: Ctrl+E to show all fields ----------
+
+func TestUpdate_CtrlE_RevealsSkippedFields(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.ctrle",
+		Name: "ctrle",
+		Parameters: []domain.Parameter{
+			stringParam("a", true, "global"),
+			stringParam("b", true, "global"),
+		},
+	}
+	resolved := map[string]string{"a": "saved"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved})
+
+	if m.SkippedCount() != 1 {
+		t.Fatalf("expected 1 skipped, got %d", m.SkippedCount())
+	}
+
+	// Send Ctrl+E.
+	ctrlE := tea.KeyPressMsg{Text: "e", Mod: tea.ModCtrl}
+	m, _ = m.Update(ctrlE)
+
+	if !m.showAll {
+		t.Error("showAll should be true after Ctrl+E")
+	}
+	if m.SkippedCount() != 0 {
+		t.Errorf("skipped count should be 0 after Ctrl+E, got %d", m.SkippedCount())
+	}
+}
+
+func TestUpdate_CtrlE_NoopWhenNothingSkipped(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.ctrle",
+		Name:       "ctrle",
+		Parameters: []domain.Parameter{stringParam("a", true, "global")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	ctrlE := tea.KeyPressMsg{Text: "e", Mod: tea.ModCtrl}
+	m, _ = m.Update(ctrlE)
+
+	// showAll should remain false — nothing to reveal.
+	if m.showAll {
+		t.Error("showAll should not change when no fields are skipped")
+	}
+}
+
+// ---------- Update: shift+tab goes back ----------
+
+func TestUpdate_ShiftTab_GoesBack(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.back",
+		Name: "back",
+		Parameters: []domain.Parameter{
+			localStringParam("a", true),
+			localStringParam("b", true),
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Fill field a and advance.
+	m.input.SetValue("val_a")
+	m, _ = m.Update(enterMsg())
+	if m.current != 1 {
+		t.Fatalf("expected to be on field 1, got %d", m.current)
+	}
+
+	// Shift+tab to go back.
+	shiftTab := tea.KeyPressMsg{Text: "shift+tab"}
+	m, _ = m.Update(shiftTab)
+	if m.current != 0 {
+		t.Errorf("shift+tab should go back to field 0, got %d", m.current)
+	}
+}
+
+func TestUpdate_ShiftTab_AtFirstField(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.back",
+		Name:       "back",
+		Parameters: []domain.Parameter{localStringParam("a", true)},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	shiftTab := tea.KeyPressMsg{Text: "shift+tab"}
+	m, _ = m.Update(shiftTab)
+	if m.current != 0 {
+		t.Error("shift+tab at first field should stay at 0")
+	}
+}
+
+// ---------- advance: skipping logic ----------
+
+func TestAdvance_SkipsPrefilled(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.skip",
+		Name: "skip",
+		Parameters: []domain.Parameter{
+			localStringParam("a", true),
+			localStringParam("b", true), // prefilled → should be skipped
+			localStringParam("c", true),
+		},
+	}
+	resolved := map[string]string{"b": "saved_b"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved})
+
+	// Should start at field 0 (a is not prefilled).
+	if m.current != 0 {
+		t.Fatalf("expected to start at 0, got %d", m.current)
+	}
+
+	// Fill a and advance — should skip b and land on c.
+	m.input.SetValue("val_a")
+	m, _ = m.Update(enterMsg())
+
+	if m.current != 2 {
+		t.Errorf("should skip to field 2, got %d", m.current)
+	}
+	if !m.skipped[1] {
+		t.Error("field 1 should be marked as skipped")
+	}
+	if m.values["b"] != "saved_b" {
+		t.Errorf("skipped field b should have value saved_b, got %q", m.values["b"])
+	}
+}
+
+func TestAdvance_AllRemainingSkipped_Submits(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.skip",
+		Name: "skip",
+		Parameters: []domain.Parameter{
+			localStringParam("a", true),
+			localStringParam("b", true),
+		},
+	}
+	resolved := map[string]string{"b": "saved_b"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved})
+
+	m.input.SetValue("val_a")
+	m, cmd := m.Update(enterMsg())
+
+	if cmd == nil {
+		t.Fatal("should submit when all remaining fields are skipped")
+	}
+	msg := cmd()
+	sub, ok := msg.(SubmitMsg)
+	if !ok {
+		t.Fatalf("expected SubmitMsg, got %T", msg)
+	}
+	if sub.Params["a"] != "val_a" {
+		t.Errorf("expected a=val_a, got %q", sub.Params["a"])
+	}
+	if sub.Params["b"] != "saved_b" {
+		t.Errorf("expected b=saved_b, got %q", sub.Params["b"])
+	}
+}
+
+// ---------- advanceOrSave: scope-based save prompt ----------
+
+func TestAdvanceOrSave_LocalScope_NoSavePrompt(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.local",
+		Name: "local",
+		Parameters: []domain.Parameter{
+			{Name: "x", Type: domain.ParamString, Required: true, Scope: "local"},
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m.input.SetValue("val")
+	m, cmd := m.Update(enterMsg())
+
+	// Local scope should not trigger save prompt — should submit directly.
+	if m.phase == phaseSave {
+		t.Error("local scope should not trigger save prompt")
+	}
+	if cmd == nil {
+		t.Fatal("should submit for local scope")
+	}
+}
+
+func TestAdvanceOrSave_EmptyScope_NoSavePrompt(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.noscope",
+		Name: "noscope",
+		Parameters: []domain.Parameter{
+			{Name: "x", Type: domain.ParamString, Required: true, Scope: ""},
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m.input.SetValue("val")
+	m, cmd := m.Update(enterMsg())
+
+	if m.phase == phaseSave {
+		t.Error("empty scope should not trigger save prompt")
+	}
+	if cmd == nil {
+		t.Fatal("should submit")
+	}
+}
+
+func TestAdvanceOrSave_GlobalScope_ShowsSavePrompt(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.global",
+		Name: "global",
+		Parameters: []domain.Parameter{
+			stringParam("x", true, "global"),
+			stringParam("y", true, "global"),
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m.input.SetValue("newval")
+	m, _ = m.Update(enterMsg())
+
+	if m.phase != phaseSave {
+		t.Error("global scope with new value should trigger save prompt")
+	}
+}
+
+// ---------- Update: save confirm phase ----------
+
+func TestUpdate_SaveConfirm_YKey(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.save",
+		Name: "save",
+		Parameters: []domain.Parameter{
+			stringParam("x", true, "global"),
+			stringParam("y", true, "global"),
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Enter a value to trigger save prompt.
+	m.input.SetValue("newval")
+	m, _ = m.Update(enterMsg())
+	if m.phase != phaseSave {
+		t.Fatal("should be in save phase")
+	}
+
+	// Press 'n' to decline save and advance.
+	m, _ = m.Update(textKeyMsg("n"))
+	if m.phase == phaseSave {
+		t.Error("should have exited save phase")
+	}
+	if m.current != 1 {
+		t.Errorf("should advance to field 1, got %d", m.current)
+	}
+}
+
+func TestUpdate_SaveConfirm_EnterWithCursorOnNo(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.save",
+		Name: "save",
+		Parameters: []domain.Parameter{
+			stringParam("x", true, "global"),
+			stringParam("y", true, "global"),
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m.input.SetValue("newval")
+	m, _ = m.Update(enterMsg())
+	if m.phase != phaseSave {
+		t.Fatal("should be in save phase")
+	}
+
+	// Cursor defaults to 1 (No). Enter should decline save.
+	if m.cursor != 1 {
+		t.Errorf("save confirm default cursor should be 1 (No), got %d", m.cursor)
+	}
+	m, _ = m.Update(enterMsg())
+	if m.current != 1 {
+		t.Errorf("should advance to next field, got %d", m.current)
+	}
+}
+
+func TestUpdate_SaveConfirm_ToggleNavigation(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.save",
+		Name: "save",
+		Parameters: []domain.Parameter{
+			stringParam("x", true, "global"),
+			stringParam("y", true, "global"),
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m.input.SetValue("val")
+	m, _ = m.Update(enterMsg())
+	if m.phase != phaseSave {
+		t.Fatal("should be in save phase")
+	}
+
+	// Left moves to Yes.
+	m, _ = m.Update(keyMsg(tea.KeyLeft))
+	if m.cursor != 0 {
+		t.Error("left should move to Yes (0)")
+	}
+
+	// Right moves to No.
+	m, _ = m.Update(textKeyMsg("l"))
+	if m.cursor != 1 {
+		t.Error("l should move to No (1)")
+	}
+}
+
+// ---------- View tests ----------
+
+func TestView_EmptyParams(t *testing.T) {
+	rb := domain.Runbook{ID: "test.empty", Name: "empty"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	view := m.View()
+	if view != "" {
+		t.Errorf("empty params view should be empty, got %q", view)
+	}
+}
+
+func TestView_ShowsFieldName(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.view",
+		Name:       "view",
+		Parameters: []domain.Parameter{stringParam("my_field", true, "global")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	view := m.View()
+	if !strings.Contains(view, "my_field") {
+		t.Error("view should contain field name")
+	}
+}
+
+func TestView_SelectOptions(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.view",
+		Name:       "view",
+		Parameters: []domain.Parameter{selectParam("env", []string{"dev", "staging", "prod"})},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	view := m.View()
+	for _, opt := range []string{"dev", "staging", "prod"} {
+		if !strings.Contains(view, opt) {
+			t.Errorf("view should contain option %q", opt)
+		}
+	}
+}
+
+func TestView_BooleanToggle(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.view",
+		Name:       "view",
+		Parameters: []domain.Parameter{boolParam("flag")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	view := m.View()
+	if !strings.Contains(view, "Yes") || !strings.Contains(view, "No") {
+		t.Error("boolean view should contain Yes and No")
+	}
+}
+
+func TestView_MultiSelectCheckboxes(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.view",
+		Name:       "view",
+		Parameters: []domain.Parameter{multiSelectParam("tags", []string{"a", "b"})},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	view := m.View()
+	if !strings.Contains(view, "[ ]") {
+		t.Error("view should show unchecked boxes")
+	}
+
+	// Toggle first, check [x] appears.
+	m, _ = m.Update(textKeyMsg(" "))
+	view = m.View()
+	if !strings.Contains(view, "[x]") {
+		t.Error("view should show checked box after toggle")
+	}
+}
+
+func TestView_CompletedFields(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.view",
+		Name: "view",
+		Parameters: []domain.Parameter{
+			stringParam("a", true, "global"),
+			stringParam("b", true, "global"),
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Complete field a.
+	m.input.SetValue("val_a")
+	m, _ = m.Update(enterMsg())
+	// Skip save if prompted.
+	if m.phase == phaseSave {
+		m, _ = m.Update(textKeyMsg("n"))
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "val_a") {
+		t.Error("view should show completed value for first field")
+	}
+}
+
+func TestView_SecretFieldMasked(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.secret",
+		Name: "secret",
+		Parameters: []domain.Parameter{
+			secretParam("token"),
+			stringParam("name", true, "global"),
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Fill secret and advance.
+	m.input.SetValue("supersecret")
+	m, _ = m.Update(enterMsg())
+	// Skip save if prompted.
+	if m.phase == phaseSave {
+		m, _ = m.Update(textKeyMsg("n"))
+	}
+
+	view := m.View()
+	if strings.Contains(view, "supersecret") {
+		t.Error("view should NOT show secret value in plain text")
+	}
+	if !strings.Contains(view, "••••••••••") {
+		t.Error("view should show masked dots for secret")
+	}
+}
+
+func TestView_SavePrompt(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.save",
+		Name: "save",
+		Parameters: []domain.Parameter{
+			stringParam("x", true, "global"),
+			stringParam("y", true, "global"),
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m.input.SetValue("newval")
+	m, _ = m.Update(enterMsg())
+
+	if m.phase != phaseSave {
+		t.Fatal("should be in save phase")
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "Save for future runs?") {
+		t.Error("view should show save prompt")
+	}
+}
+
+func TestView_ErrorDisplayed(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.err",
+		Name:       "err",
+		Parameters: []domain.Parameter{stringParam("x", true, "global")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Submit empty required field to trigger error.
+	m, _ = m.Update(enterMsg())
+	view := m.View()
+	if !strings.Contains(view, "required field") {
+		t.Error("view should display validation error")
+	}
+}
+
+func TestView_SkippedSummary(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.skip",
+		Name: "skip",
+		Parameters: []domain.Parameter{
+			stringParam("a", true, "global"),
+			stringParam("b", true, "global"),
+			stringParam("c", true, "global"),
+		},
+	}
+	resolved := map[string]string{"a": "va", "b": "vb"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved})
+
+	view := m.View()
+	if !strings.Contains(view, "Applied 2 saved values") {
+		t.Error("view should show plural skipped summary")
+	}
+	if !strings.Contains(view, "Ctrl+E") {
+		t.Error("view should mention Ctrl+E")
+	}
+}
+
+// ---------- FooterHints tests ----------
+
+func TestFooterHints_EmptyParams(t *testing.T) {
+	rb := domain.Runbook{ID: "test.empty", Name: "empty"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	if m.FooterHints() != "" {
+		t.Error("footer hints should be empty for no params")
+	}
+}
+
+func TestFooterHints_SelectField(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.sel",
+		Name:       "sel",
+		Parameters: []domain.Parameter{selectParam("env", []string{"dev"})},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	hints := m.FooterHints()
+	if !strings.Contains(hints, "navigate") {
+		t.Errorf("select hints should mention navigate, got %q", hints)
+	}
+}
+
+func TestFooterHints_MultiSelectField(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.ms",
+		Name:       "ms",
+		Parameters: []domain.Parameter{multiSelectParam("tags", []string{"a"})},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	hints := m.FooterHints()
+	if !strings.Contains(hints, "Space") || !strings.Contains(hints, "toggle") {
+		t.Errorf("multi-select hints should mention Space toggle, got %q", hints)
+	}
+}
+
+func TestFooterHints_BooleanField(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.bool",
+		Name:       "bool",
+		Parameters: []domain.Parameter{boolParam("flag")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	hints := m.FooterHints()
+	if !strings.Contains(hints, "toggle") {
+		t.Errorf("boolean hints should mention toggle, got %q", hints)
+	}
+}
+
+func TestFooterHints_TextWithBackOption(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.hints",
+		Name: "hints",
+		Parameters: []domain.Parameter{
+			stringParam("a", true, "global"),
+			stringParam("b", true, "global"),
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// First field should not show "back".
+	hints := m.FooterHints()
+	if strings.Contains(hints, "shift+tab") {
+		t.Error("first field should not show shift+tab")
+	}
+
+	// Advance to second field.
+	m.input.SetValue("val")
+	m, _ = m.Update(enterMsg())
+	if m.phase == phaseSave {
+		m, _ = m.Update(textKeyMsg("n"))
+	}
+
+	hints = m.FooterHints()
+	if !strings.Contains(hints, "shift+tab") {
+		t.Error("second field should show shift+tab back")
+	}
+}
+
+func TestFooterHints_SavePhase(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.save",
+		Name: "save",
+		Parameters: []domain.Parameter{
+			stringParam("x", true, "global"),
+			stringParam("y", true, "global"),
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m.input.SetValue("val")
+	m, _ = m.Update(enterMsg())
+	if m.phase != phaseSave {
+		t.Skip("not in save phase")
+	}
+
+	hints := m.FooterHints()
+	if !strings.Contains(hints, "toggle") || !strings.Contains(hints, "confirm") {
+		t.Errorf("save phase hints should mention toggle and confirm, got %q", hints)
+	}
+}
+
+func TestFooterHints_SecretPrefilled(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.secret",
+		Name:       "secret",
+		Parameters: []domain.Parameter{secretParam("token")},
+	}
+	resolved := map[string]string{"token": "saved_secret"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved, PromptAll: true})
+
+	hints := m.FooterHints()
+	if !strings.Contains(hints, "accept") {
+		t.Errorf("secret prefilled hints should mention accept, got %q", hints)
+	}
+}
+
+// ---------- Edge cases ----------
+
+func TestSingleParam_SubmitsDirectly(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.single",
+		Name:       "single",
+		Parameters: []domain.Parameter{stringParam("only", false, "local")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	m.input.SetValue("val")
+	m, cmd := m.Update(enterMsg())
+	if cmd == nil {
+		t.Fatal("single param should submit after enter")
+	}
+	msg := cmd()
+	sub, ok := msg.(SubmitMsg)
+	if !ok {
+		t.Fatalf("expected SubmitMsg, got %T", msg)
+	}
+	if sub.Params["only"] != "val" {
+		t.Errorf("expected only=val, got %q", sub.Params["only"])
+	}
+}
+
+func TestCollectParams_MergesResolvedAndValues(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.merge",
+		Name: "merge",
+		Parameters: []domain.Parameter{
+			localStringParam("a", true),
+			localStringParam("b", true),
+		},
+	}
+	resolved := map[string]string{"a": "resolved_a"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved, PromptAll: true})
+
+	// Fill a with a new value.
+	m.input.SetValue("new_a")
+	m, _ = m.Update(enterMsg())
+	if m.phase == phaseSave {
+		m, _ = m.Update(textKeyMsg("n"))
+	}
+
+	// Fill b.
+	m.input.SetValue("val_b")
+	m, cmd := m.Update(enterMsg())
+	if m.phase == phaseSave {
+		m, _ = m.Update(textKeyMsg("n"))
+		// After declining save, advance triggers submit.
+		// Need to get cmd from last update.
+	}
+
+	// The final cmd might be from the save decline.
+	if cmd == nil {
+		t.Fatal("should produce submit command")
+	}
+	msg := cmd()
+	sub, ok := msg.(SubmitMsg)
+	if !ok {
+		t.Fatalf("expected SubmitMsg, got %T", msg)
+	}
+	// User-entered value should override resolved.
+	if sub.Params["a"] != "new_a" {
+		t.Errorf("expected a=new_a (override), got %q", sub.Params["a"])
+	}
+	if sub.Params["b"] != "val_b" {
+		t.Errorf("expected b=val_b, got %q", sub.Params["b"])
+	}
+}
+
+func TestNewModel_DefaultValue(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.default",
+		Name: "default",
+		Parameters: []domain.Parameter{
+			{Name: "x", Type: domain.ParamString, Required: false, Scope: "global", Default: "mydefault"},
+		},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+
+	// Text input should have default value pre-populated.
+	if m.input.Value() != "mydefault" {
+		t.Errorf("expected default value 'mydefault', got %q", m.input.Value())
+	}
+}
+
+func TestBuildCommand_SecretMasked(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.cmd",
+		Name: "cmd",
+		Parameters: []domain.Parameter{
+			secretParam("token"),
+			stringParam("name", true, "global"),
+		},
+	}
+	params := map[string]string{"token": "supersecret", "name": "test"}
+
+	cmd := BuildCommand(rb, params)
+	if strings.Contains(cmd, "supersecret") {
+		t.Error("command should not contain secret in plain text")
+	}
+	if !strings.Contains(cmd, "••••••••••") {
+		t.Error("command should mask secret with dots")
+	}
+	if !strings.Contains(cmd, "name=test") {
+		t.Error("command should show non-secret params")
+	}
+}
+
+func TestBuildCommand_ConfigParamsOmitted(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.cmd",
+		Name: "cmd",
+		Parameters: []domain.Parameter{
+			stringParam("a", true, "global"),
+			stringParam("b", true, "global"),
+		},
+	}
+	params := map[string]string{"a": "va", "b": "vb"}
+	saved := map[string]string{"a": "va"} // a is unchanged from config
+
+	cmd := BuildCommand(rb, params, saved)
+	if strings.Contains(cmd, "a=va") {
+		t.Error("unchanged config param should be omitted from command")
+	}
+	if !strings.Contains(cmd, "b=vb") {
+		t.Error("new param should be included in command")
+	}
+}
+
+func TestInitField_SelectPrefillsCursor(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.selfill",
+		Name:       "selfill",
+		Parameters: []domain.Parameter{selectParam("env", []string{"dev", "staging", "prod"})},
+	}
+	resolved := map[string]string{"env": "prod"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved, PromptAll: true})
+
+	if m.cursor != 2 {
+		t.Errorf("cursor should be at index 2 (prod), got %d", m.cursor)
+	}
+}
+
+func TestInitField_BooleanPrefillsCursor(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.boolfill",
+		Name:       "boolfill",
+		Parameters: []domain.Parameter{boolParam("flag")},
+	}
+	resolved := map[string]string{"flag": "true"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved, PromptAll: true})
+
+	if m.cursor != 0 {
+		t.Errorf("boolean cursor should be 0 (Yes) when prefilled true, got %d", m.cursor)
+	}
+}
+
+func TestInitField_MultiSelectPrefillsChecked(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.msfill",
+		Name:       "msfill",
+		Parameters: []domain.Parameter{multiSelectParam("tags", []string{"a", "b", "c"})},
+	}
+	resolved := map[string]string{"tags": "a, c"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved, PromptAll: true})
+
+	if !m.checked[0] {
+		t.Error("a (index 0) should be checked")
+	}
+	if m.checked[1] {
+		t.Error("b (index 1) should not be checked")
+	}
+	if !m.checked[2] {
+		t.Error("c (index 2) should be checked")
+	}
+}
+
+func TestGoBack_SkipsOverSkippedFields(t *testing.T) {
+	rb := domain.Runbook{
+		ID:   "test.goback",
+		Name: "goback",
+		Parameters: []domain.Parameter{
+			localStringParam("a", true),
+			localStringParam("b", true), // will be prefilled/skipped
+			localStringParam("c", true),
+		},
+	}
+	resolved := map[string]string{"b": "saved_b"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved})
+
+	// Should start at field 0.
+	if m.current != 0 {
+		t.Fatalf("expected start at 0, got %d", m.current)
+	}
+
+	// Fill a and advance — should skip b and land on c (index 2).
+	m.input.SetValue("val_a")
+	m, _ = m.Update(enterMsg())
+	if m.current != 2 {
+		t.Fatalf("expected to be at 2, got %d", m.current)
+	}
+
+	// Shift+tab from c should go back to a (index 0), skipping b.
+	shiftTab := tea.KeyPressMsg{Text: "shift+tab"}
+	m, _ = m.Update(shiftTab)
+	if m.current != 0 {
+		t.Errorf("should go back to field 0 (skipping 1), got %d", m.current)
+	}
+}
+
+func TestSecretField_NoPrefill_EchoPassword(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.secret",
+		Name:       "secret",
+		Parameters: []domain.Parameter{secretParam("token")},
+	}
+	// No resolved value — secret without prefill should use EchoPassword.
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	if m.input.EchoMode != textinput.EchoPassword {
+		t.Errorf("secret without prefill should use EchoPassword, got %d", m.input.EchoMode)
+	}
+}
+
+func TestSecretField_WithPrefill_NormalEcho(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.secret",
+		Name:       "secret",
+		Parameters: []domain.Parameter{secretParam("token")},
+	}
+	resolved := map[string]string{"token": "saved_secret"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved, PromptAll: true})
+	// Secret with prefill should NOT start in EchoPassword mode (manual dots shown).
+	if m.input.EchoMode == textinput.EchoPassword {
+		t.Error("secret with prefill should NOT use EchoPassword initially")
+	}
+}
+
+func TestView_SecretPrefilled_ShowsDots(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.secret",
+		Name:       "secret",
+		Parameters: []domain.Parameter{secretParam("token")},
+	}
+	resolved := map[string]string{"token": "saved_secret"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved, PromptAll: true})
+	view := m.View()
+	// Should show dots hint for prefilled secret.
+	if !strings.Contains(view, "••••••••••") {
+		t.Error("prefilled secret should show dots placeholder")
+	}
+	if strings.Contains(view, "saved_secret") {
+		t.Error("prefilled secret value should not be visible")
+	}
+}
+
+func TestSecretField_EmptyInputKeepsSaved(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.secret",
+		Name:       "secret",
+		Parameters: []domain.Parameter{secretParam("token")},
+	}
+	resolved := map[string]string{"token": "saved_secret"}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog(), Resolved: resolved, PromptAll: true})
+
+	// Press enter with empty input — should keep saved value.
+	m, cmd := m.Update(enterMsg())
+	if m.values["token"] != "saved_secret" {
+		t.Errorf("expected saved secret to be kept, got %q", m.values["token"])
+	}
+	if cmd == nil {
+		t.Fatal("should submit after accepting saved secret")
+	}
+}

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -117,9 +117,12 @@ func writeCache(path, latest string) {
 	_ = os.WriteFile(path, data, 0o600)
 }
 
+// apiBaseURL is the GitHub API base URL. Override in tests to use httptest.
+var apiBaseURL = "https://api.github.com"
+
 // fetchLatest hits the GitHub Releases API and returns the latest version tag.
 func fetchLatest() (string, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", githubRepo)
+	url := fmt.Sprintf("%s/repos/%s/releases/latest", apiBaseURL, githubRepo)
 
 	client := &http.Client{Timeout: httpTimeout}
 	resp, err := client.Get(url) // nolint:noctx -- fire-and-forget update check

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -140,38 +140,152 @@ func TestReadCache_NoUpdate(t *testing.T) {
 	}
 }
 
+// withMockAPI starts an httptest server, points apiBaseURL at it, and restores
+// the original URL when the test finishes.
+func withMockAPI(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	orig := apiBaseURL
+	apiBaseURL = srv.URL
+	t.Cleanup(func() {
+		apiBaseURL = orig
+		srv.Close()
+	})
+	return srv
+}
+
 func TestFetchLatest_Success(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	withMockAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(githubRelease{TagName: "v0.3.0"})
 	}))
-	defer srv.Close()
 
-	// Override the fetch function via a test helper.
-	result := fetchLatestFrom(srv.URL)
-	if result != "0.3.0" {
-		t.Errorf("got %q, want %q", result, "0.3.0")
-	}
-}
-
-// fetchLatestFrom is a test helper that hits an arbitrary URL.
-func fetchLatestFrom(url string) string {
-	client := &http.Client{Timeout: httpTimeout}
-	resp, err := client.Get(url)
+	got, err := fetchLatest()
 	if err != nil {
-		return ""
+		t.Fatal(err)
 	}
-	defer resp.Body.Close()
-
-	var release githubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return ""
+	if got != "0.3.0" {
+		t.Errorf("got %q, want %q", got, "0.3.0")
 	}
-	return trimV(release.TagName)
 }
 
-func trimV(s string) string {
-	if len(s) > 0 && s[0] == 'v' {
-		return s[1:]
+func TestFetchLatest_NonOK(t *testing.T) {
+	withMockAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	_, err := fetchLatest()
+	if err == nil {
+		t.Fatal("expected error for non-200 response")
 	}
-	return s
+}
+
+func TestFetchLatest_BadJSON(t *testing.T) {
+	withMockAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+
+	_, err := fetchLatest()
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestWriteCache(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", cacheFile) // sub-dir to test MkdirAll
+
+	writeCache(path, "1.2.3")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal("cache file not written:", err)
+	}
+
+	var c cache
+	if err := json.Unmarshal(data, &c); err != nil {
+		t.Fatal("invalid JSON in cache:", err)
+	}
+	if c.Latest != "1.2.3" {
+		t.Errorf("cached latest = %q, want %q", c.Latest, "1.2.3")
+	}
+	if _, err := time.Parse(time.RFC3339, c.CheckedAt); err != nil {
+		t.Errorf("cached checked_at not valid RFC3339: %v", err)
+	}
+}
+
+func TestCheck_UpdateAvailable(t *testing.T) {
+	withMockAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(githubRelease{TagName: "v1.0.0"})
+	}))
+
+	dir := t.TempDir()
+	result := Check("0.1.0", dir)
+	if !result.Available {
+		t.Error("expected Available=true")
+	}
+	if result.Latest != "1.0.0" {
+		t.Errorf("Latest = %q, want %q", result.Latest, "1.0.0")
+	}
+
+	// Verify cache was written.
+	data, err := os.ReadFile(filepath.Join(dir, cacheFile))
+	if err != nil {
+		t.Fatal("cache not written after Check")
+	}
+	var c cache
+	json.Unmarshal(data, &c)
+	if c.Latest != "1.0.0" {
+		t.Errorf("cached latest = %q", c.Latest)
+	}
+}
+
+func TestCheck_NoUpdate(t *testing.T) {
+	withMockAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(githubRelease{TagName: "v0.1.0"})
+	}))
+
+	dir := t.TempDir()
+	result := Check("0.1.0", dir)
+	if result.Available {
+		t.Error("expected Available=false when versions match")
+	}
+}
+
+func TestCheck_SkipsDevVersion(t *testing.T) {
+	result := Check("dev", t.TempDir())
+	if result.Available {
+		t.Error("expected Available=false for dev version")
+	}
+}
+
+func TestCheck_UsesCache(t *testing.T) {
+	// Pre-populate a fresh cache.
+	dir := t.TempDir()
+	c := cache{
+		CheckedAt: time.Now().UTC().Format(time.RFC3339),
+		Latest:    "2.0.0",
+	}
+	data, _ := json.Marshal(c)
+	os.WriteFile(filepath.Join(dir, cacheFile), data, 0o644)
+
+	// Point API at a server that would return a different version.
+	withMockAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(githubRelease{TagName: "v3.0.0"})
+	}))
+
+	result := Check("0.1.0", dir)
+	if result.Latest != "2.0.0" {
+		t.Errorf("should use cached version 2.0.0, got %q", result.Latest)
+	}
+}
+
+func TestCheck_APIError(t *testing.T) {
+	withMockAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	result := Check("0.1.0", t.TempDir())
+	if result.Available {
+		t.Error("expected Available=false on API error")
+	}
 }

--- a/internal/vars/resolver_test.go
+++ b/internal/vars/resolver_test.go
@@ -82,6 +82,57 @@ func TestDefaultVarResolver_EmptyScopes(t *testing.T) {
 	}
 }
 
+func TestToString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{"string", "hello", "hello"},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+		{"float64 integer", float64(42), "42"},
+		{"float64 decimal", 3.14, "3.14"},
+		{"float64 zero", float64(0), "0"},
+		{"int via default", 99, "99"},
+		{"nil via default", nil, "<nil>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toString(tt.input)
+			if got != tt.want {
+				t.Errorf("toString(%v) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultVarResolver_FloatValues(t *testing.T) {
+	cfg := &domain.Config{
+		Vars: domain.Vars{
+			Global: map[string]any{
+				"count":   float64(5),
+				"ratio":   3.14,
+			},
+		},
+	}
+
+	params := []domain.Parameter{
+		{Name: "count", Scope: "global"},
+		{Name: "ratio", Scope: "global"},
+	}
+
+	resolver := NewDefaultResolver()
+	result := resolver.Resolve(cfg, "default", "test", params)
+
+	if result["count"] != "5" {
+		t.Errorf("count = %q, want 5", result["count"])
+	}
+	if result["ratio"] != "3.14" {
+		t.Errorf("ratio = %q, want 3.14", result["ratio"])
+	}
+}
+
 func TestDefaultVarResolver_MissingCatalog(t *testing.T) {
 	cfg := &domain.Config{
 		Vars: domain.Vars{

--- a/internal/vault/vault_extra_test.go
+++ b/internal/vault/vault_extra_test.go
@@ -1,0 +1,312 @@
+package vault
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dops/internal/crypto"
+	"dops/internal/domain"
+)
+
+// helper creates a vault backed by a temp directory with a real age key.
+func newTestVault(t *testing.T) (*Vault, string) {
+	t.Helper()
+	dir := t.TempDir()
+	keysDir := filepath.Join(dir, "keys")
+	vaultPath := filepath.Join(dir, "vault.json")
+	return New(vaultPath, keysDir), dir
+}
+
+func TestNew(t *testing.T) {
+	v := New("/tmp/vault.json", "/tmp/keys")
+	if v.path != "/tmp/vault.json" {
+		t.Errorf("path = %q, want /tmp/vault.json", v.path)
+	}
+	if v.keysDir != "/tmp/keys" {
+		t.Errorf("keysDir = %q, want /tmp/keys", v.keysDir)
+	}
+}
+
+func TestExists_NoFile(t *testing.T) {
+	v, _ := newTestVault(t)
+	if v.Exists() {
+		t.Error("Exists() should return false when vault file does not exist")
+	}
+}
+
+func TestExists_WithFile(t *testing.T) {
+	v, _ := newTestVault(t)
+	if err := os.WriteFile(v.path, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !v.Exists() {
+		t.Error("Exists() should return true when vault file exists")
+	}
+}
+
+func TestLoad_NonExistentFile_ReturnsEmptyVars(t *testing.T) {
+	v, _ := newTestVault(t)
+	vars, err := v.Load()
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+	if vars == nil {
+		t.Fatal("Load() returned nil vars")
+	}
+}
+
+func TestLoad_InvalidJSON(t *testing.T) {
+	v, _ := newTestVault(t)
+	if err := os.WriteFile(v.path, []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := v.Load()
+	if err == nil {
+		t.Fatal("Load() expected error for invalid JSON")
+	}
+}
+
+func TestLoad_UnsupportedVersion(t *testing.T) {
+	v, _ := newTestVault(t)
+	env := envelope{Version: 999, Data: "irrelevant"}
+	data, _ := json.Marshal(env)
+	if err := os.WriteFile(v.path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := v.Load()
+	if err == nil {
+		t.Fatal("Load() expected error for unsupported version")
+	}
+}
+
+func TestLoad_CorruptedCiphertext(t *testing.T) {
+	v, _ := newTestVault(t)
+	// Version is correct but data is not valid age ciphertext.
+	env := envelope{Version: 1, Data: "not-valid-ciphertext"}
+	data, _ := json.Marshal(env)
+	if err := os.WriteFile(v.path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := v.Load()
+	if err == nil {
+		t.Fatal("Load() expected error for corrupted ciphertext")
+	}
+}
+
+func TestSaveAndLoad_RoundTrip(t *testing.T) {
+	v, _ := newTestVault(t)
+	vars := &domain.Vars{
+		Global: map[string]any{
+			"region": "us-west-2",
+		},
+	}
+
+	if err := v.Save(vars); err != nil {
+		t.Fatalf("Save() unexpected error: %v", err)
+	}
+
+	if !v.Exists() {
+		t.Fatal("vault file should exist after Save")
+	}
+
+	loaded, err := v.Load()
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	val, ok := loaded.Global["region"]
+	if !ok {
+		t.Fatal("expected 'region' in loaded vars")
+	}
+	if val != "us-west-2" {
+		t.Errorf("region = %v, want us-west-2", val)
+	}
+}
+
+func TestSave_FilePermissions(t *testing.T) {
+	v, _ := newTestVault(t)
+	vars := &domain.Vars{}
+
+	if err := v.Save(vars); err != nil {
+		t.Fatalf("Save() unexpected error: %v", err)
+	}
+
+	info, err := os.Stat(v.path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm != 0o600 {
+		t.Errorf("file permissions = %o, want 600", perm)
+	}
+}
+
+func TestSave_CreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	keysDir := filepath.Join(dir, "keys")
+	vaultPath := filepath.Join(dir, "nested", "deep", "vault.json")
+	v := New(vaultPath, keysDir)
+
+	vars := &domain.Vars{}
+	if err := v.Save(vars); err != nil {
+		t.Fatalf("Save() unexpected error: %v", err)
+	}
+
+	if !v.Exists() {
+		t.Error("vault file should exist after Save in nested dir")
+	}
+}
+
+func TestSave_InvalidDirectory(t *testing.T) {
+	// Use /dev/null as parent dir (not a directory) to force MkdirAll failure.
+	v := New("/dev/null/impossible/vault.json", t.TempDir())
+	vars := &domain.Vars{}
+	err := v.Save(vars)
+	if err == nil {
+		t.Fatal("Save() expected error when directory creation fails")
+	}
+}
+
+func TestSave_OverwritesExisting(t *testing.T) {
+	v, _ := newTestVault(t)
+
+	// Save initial data.
+	vars1 := &domain.Vars{Global: map[string]any{"key": "value1"}}
+	if err := v.Save(vars1); err != nil {
+		t.Fatalf("Save() #1: %v", err)
+	}
+
+	// Save different data.
+	vars2 := &domain.Vars{Global: map[string]any{"key": "value2"}}
+	if err := v.Save(vars2); err != nil {
+		t.Fatalf("Save() #2: %v", err)
+	}
+
+	loaded, err := v.Load()
+	if err != nil {
+		t.Fatalf("Load(): %v", err)
+	}
+
+	if loaded.Global["key"] != "value2" {
+		t.Errorf("key = %v, want value2", loaded.Global["key"])
+	}
+}
+
+func TestLoad_ValidEnvelopeButBadDecryptedJSON(t *testing.T) {
+	v, _ := newTestVault(t)
+
+	// Encrypt something that is NOT valid JSON for domain.Vars.
+	enc, err := crypto.NewAgeEncrypter(v.keysDir)
+	if err != nil {
+		t.Fatalf("NewAgeEncrypter: %v", err)
+	}
+
+	ciphertext, err := enc.Encrypt("not valid json for vars")
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	env := envelope{Version: 1, Data: ciphertext}
+	data, _ := json.Marshal(env)
+	if err := os.WriteFile(v.path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = v.Load()
+	if err == nil {
+		t.Fatal("Load() expected error for invalid decrypted JSON")
+	}
+}
+
+func TestLoad_UnreadableFile(t *testing.T) {
+	v, _ := newTestVault(t)
+	// Create the file but make it unreadable.
+	if err := os.WriteFile(v.path, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(v.path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(v.path, 0o600) })
+
+	_, err := v.Load()
+	if err == nil {
+		t.Fatal("Load() expected error for unreadable file")
+	}
+}
+
+func TestSave_ReadOnlyTargetDir(t *testing.T) {
+	// Create a directory, save once, then make the directory read-only.
+	// The second save should fail at either CreateTemp or Rename.
+	dir := t.TempDir()
+	keysDir := filepath.Join(dir, "keys")
+	targetDir := filepath.Join(dir, "vault-dir")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	vaultPath := filepath.Join(targetDir, "vault.json")
+	v := New(vaultPath, keysDir)
+
+	vars := &domain.Vars{}
+	// First save should succeed.
+	if err := v.Save(vars); err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+
+	// Make the directory read-only so temp file creation fails.
+	if err := os.Chmod(targetDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(targetDir, 0o755) })
+
+	err := v.Save(vars)
+	if err == nil {
+		t.Fatal("Save() expected error when directory is read-only")
+	}
+}
+
+func TestSave_EmptyVars(t *testing.T) {
+	v, _ := newTestVault(t)
+	vars := &domain.Vars{}
+
+	if err := v.Save(vars); err != nil {
+		t.Fatalf("Save() unexpected error: %v", err)
+	}
+
+	loaded, err := v.Load()
+	if err != nil {
+		t.Fatalf("Load(): %v", err)
+	}
+
+	if loaded.Global != nil && len(loaded.Global) > 0 {
+		t.Error("expected empty global vars")
+	}
+}
+
+func TestSave_WritesValidEnvelope(t *testing.T) {
+	v, _ := newTestVault(t)
+	vars := &domain.Vars{Global: map[string]any{"x": "y"}}
+
+	if err := v.Save(vars); err != nil {
+		t.Fatalf("Save(): %v", err)
+	}
+
+	data, err := os.ReadFile(v.path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	var env envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		t.Fatalf("envelope JSON parse: %v", err)
+	}
+
+	if env.Version != vaultFormatVersion {
+		t.Errorf("version = %d, want %d", env.Version, vaultFormatVersion)
+	}
+	if env.Data == "" {
+		t.Error("envelope data should not be empty")
+	}
+}

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -1,18 +1,119 @@
 package web
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"dops/internal/domain"
+	"dops/internal/executor"
 	"dops/internal/theme"
 
 	catpkg "dops/internal/catalog"
 )
+
+// --- Mocks ---
+
+type mockLoader struct {
+	runbook *domain.Runbook
+	catalog *domain.Catalog
+	err     error
+}
+
+func (m *mockLoader) FindByID(id string) (*domain.Runbook, *domain.Catalog, error) {
+	if m.err != nil {
+		return nil, nil, m.err
+	}
+	if m.runbook != nil && m.runbook.ID == id {
+		return m.runbook, m.catalog, nil
+	}
+	return nil, nil, fmt.Errorf("not found")
+}
+
+func (m *mockLoader) FindByAlias(alias string) (*domain.Runbook, *domain.Catalog, error) {
+	if m.err != nil {
+		return nil, nil, m.err
+	}
+	if m.runbook != nil {
+		for _, a := range m.runbook.Aliases {
+			if a == alias {
+				return m.runbook, m.catalog, nil
+			}
+		}
+	}
+	return nil, nil, fmt.Errorf("not found")
+}
+
+type mockRunner struct {
+	lines []string
+	err   error
+}
+
+func (m *mockRunner) Run(_ context.Context, _ string, _ map[string]string) (<-chan executor.OutputLine, <-chan error) {
+	linesCh := make(chan executor.OutputLine, len(m.lines))
+	errsCh := make(chan error, 1)
+	for _, l := range m.lines {
+		linesCh <- executor.OutputLine{Text: l}
+	}
+	close(linesCh)
+	errsCh <- m.err
+	return linesCh, errsCh
+}
+
+type mockThemeLoader struct {
+	themes map[string]*domain.ThemeFile
+}
+
+func (m *mockThemeLoader) Load(name string) (*domain.ThemeFile, error) {
+	if tf, ok := m.themes[name]; ok {
+		return tf, nil
+	}
+	return nil, fmt.Errorf("theme %q not found", name)
+}
+
+type mockConfigStore struct {
+	saved     *domain.Config
+	saveCalls int
+}
+
+func (m *mockConfigStore) Load() (*domain.Config, error)            { return m.saved, nil }
+func (m *mockConfigStore) Save(cfg *domain.Config) error            { m.saveCalls++; m.saved = cfg; return nil }
+func (m *mockConfigStore) EnsureDefaults() (*domain.Config, error)  { return m.saved, nil }
+
+// --- Helpers ---
+
+var testRunbook = domain.Runbook{
+	ID:          "default.hello-world",
+	Name:        "hello-world",
+	Aliases:     []string{"hw"},
+	Description: "Says hello",
+	Version:     "1.0.0",
+	RiskLevel:   domain.RiskLow,
+	Script:      "./script.sh",
+	Parameters: []domain.Parameter{
+		{Name: "greeting", Type: domain.ParamString, Required: true, Description: "The greeting"},
+	},
+}
+
+var testRunbookWithSecret = domain.Runbook{
+	ID:          "default.secret-job",
+	Name:        "secret-job",
+	Description: "Has secrets",
+	Version:     "1.0.0",
+	RiskLevel:   domain.RiskLow,
+	Script:      "./run.sh",
+	Parameters: []domain.Parameter{
+		{Name: "token", Type: domain.ParamString, Required: true, Secret: true},
+		{Name: "name", Type: domain.ParamString, Required: true},
+	},
+}
+
+var testCatalog = domain.Catalog{Name: "default", DisplayName: "My Ops", Active: true}
 
 func testDeps() ServerDeps {
 	return ServerDeps{
@@ -22,28 +123,23 @@ func testDeps() ServerDeps {
 		},
 		Catalogs: []catpkg.CatalogWithRunbooks{
 			{
-				Catalog: domain.Catalog{Name: "default", DisplayName: "My Ops", Active: true},
-				Runbooks: []domain.Runbook{
-					{
-						ID:          "default.hello-world",
-						Name:        "hello-world",
-						Aliases:     []string{"hw"},
-						Description: "Says hello",
-						Version:     "1.0.0",
-						RiskLevel:   domain.RiskLow,
-						Script:      "./script.sh",
-						Parameters: []domain.Parameter{
-							{Name: "greeting", Type: domain.ParamString, Required: true, Description: "The greeting"},
-						},
-					},
-				},
+				Catalog:  testCatalog,
+				Runbooks: []domain.Runbook{testRunbook},
 			},
+		},
+		Loader: &mockLoader{
+			runbook: &testRunbook,
+			catalog: &testCatalog,
+		},
+		Runner: &mockRunner{
+			lines: []string{"hello", "world"},
 		},
 		Theme: &theme.ResolvedTheme{
 			Name:   "github",
 			Colors: map[string]string{"primary": "#58a6ff", "background": "#0d1117"},
 		},
-		Port: 0,
+		ThemeLoader: &mockThemeLoader{themes: map[string]*domain.ThemeFile{}},
+		Port:        0,
 	}
 }
 
@@ -55,6 +151,16 @@ func setupTestAPI(t *testing.T) *http.ServeMux {
 	a.registerRoutes(mux)
 	return mux
 }
+
+func setupTestAPIWithDeps(t *testing.T, deps ServerDeps) *http.ServeMux {
+	t.Helper()
+	a := newAPI(deps)
+	mux := http.NewServeMux()
+	a.registerRoutes(mux)
+	return mux
+}
+
+// --- Catalog & Runbook Tests ---
 
 func TestListCatalogs(t *testing.T) {
 	mux := setupTestAPI(t)
@@ -88,6 +194,351 @@ func TestListCatalogs(t *testing.T) {
 	}
 }
 
+func TestListCatalogs_RunbookFields(t *testing.T) {
+	mux := setupTestAPI(t)
+	req := httptest.NewRequest("GET", "/api/catalogs", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	var catalogs []catalogResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &catalogs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	rb := catalogs[0].Runbooks[0]
+	if rb.Name != "hello-world" {
+		t.Errorf("name = %q", rb.Name)
+	}
+	if rb.Description != "Says hello" {
+		t.Errorf("description = %q", rb.Description)
+	}
+	if rb.RiskLevel != "low" {
+		t.Errorf("risk_level = %q", rb.RiskLevel)
+	}
+	if rb.ParamCount != 1 {
+		t.Errorf("param_count = %d, want 1", rb.ParamCount)
+	}
+}
+
+func TestGetRunbook(t *testing.T) {
+	mux := setupTestAPI(t)
+	req := httptest.NewRequest("GET", "/api/runbooks/default.hello-world", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var detail runbookDetail
+	if err := json.Unmarshal(w.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if detail.ID != "default.hello-world" {
+		t.Errorf("id = %q", detail.ID)
+	}
+	if detail.Name != "hello-world" {
+		t.Errorf("name = %q", detail.Name)
+	}
+	if detail.Version != "1.0.0" {
+		t.Errorf("version = %q", detail.Version)
+	}
+	if detail.Script != "./script.sh" {
+		t.Errorf("script = %q", detail.Script)
+	}
+	if len(detail.Parameters) != 1 {
+		t.Fatalf("expected 1 param, got %d", len(detail.Parameters))
+	}
+	if detail.Parameters[0].Name != "greeting" {
+		t.Errorf("param name = %q", detail.Parameters[0].Name)
+	}
+}
+
+func TestGetRunbook_ByAlias(t *testing.T) {
+	mux := setupTestAPI(t)
+	req := httptest.NewRequest("GET", "/api/runbooks/hw", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var detail runbookDetail
+	if err := json.Unmarshal(w.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if detail.ID != "default.hello-world" {
+		t.Errorf("id = %q, want default.hello-world", detail.ID)
+	}
+}
+
+func TestGetRunbook_NotFound(t *testing.T) {
+	deps := testDeps()
+	deps.Loader = &mockLoader{err: fmt.Errorf("not found")}
+	mux := setupTestAPIWithDeps(t, deps)
+
+	req := httptest.NewRequest("GET", "/api/runbooks/nonexistent", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] == "" {
+		t.Error("expected error message in response")
+	}
+}
+
+func TestGetRunbook_MasksSecrets(t *testing.T) {
+	rb := testRunbookWithSecret
+	cat := testCatalog
+	deps := testDeps()
+	deps.Loader = &mockLoader{runbook: &rb, catalog: &cat}
+	deps.Catalogs = []catpkg.CatalogWithRunbooks{
+		{Catalog: cat, Runbooks: []domain.Runbook{rb}},
+	}
+	// Set up saved values that include a secret.
+	deps.Config.Vars = domain.Vars{
+		Catalog: map[string]domain.CatalogVars{
+			"default": {
+				Runbooks: map[string]map[string]any{
+					"secret-job": {"token": "supersecret", "name": "alice"},
+				},
+			},
+		},
+	}
+	mux := setupTestAPIWithDeps(t, deps)
+
+	req := httptest.NewRequest("GET", "/api/runbooks/default.secret-job", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var detail runbookDetail
+	if err := json.Unmarshal(w.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Secret param should be masked.
+	if v, ok := detail.SavedValues["token"]; ok && v != "••••••••" {
+		t.Errorf("secret value should be masked, got %q", v)
+	}
+	// Non-secret param should be visible.
+	if v := detail.SavedValues["name"]; v != "alice" {
+		t.Errorf("non-secret value = %q, want %q", v, "alice")
+	}
+}
+
+// --- Execution Tests ---
+
+func TestExecuteRunbook(t *testing.T) {
+	mux := setupTestAPI(t)
+	body := strings.NewReader(`{"params": {"greeting": "hi"}}`)
+	req := httptest.NewRequest("POST", "/api/runbooks/default.hello-world/execute", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", w.Code)
+	}
+
+	var resp executeResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ExecutionID == "" {
+		t.Error("expected non-empty execution ID")
+	}
+	if !strings.HasPrefix(resp.ExecutionID, "exec-") {
+		t.Errorf("execution id = %q, want exec-* prefix", resp.ExecutionID)
+	}
+}
+
+func TestExecuteRunbook_NotFound(t *testing.T) {
+	deps := testDeps()
+	deps.Loader = &mockLoader{err: fmt.Errorf("not found")}
+	mux := setupTestAPIWithDeps(t, deps)
+
+	body := strings.NewReader(`{"params": {}}`)
+	req := httptest.NewRequest("POST", "/api/runbooks/nonexistent/execute", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestExecuteRunbook_InvalidBody(t *testing.T) {
+	mux := setupTestAPI(t)
+	body := strings.NewReader(`not json`)
+	req := httptest.NewRequest("POST", "/api/runbooks/default.hello-world/execute", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] != "invalid request body" {
+		t.Errorf("error = %q", resp["error"])
+	}
+}
+
+func TestCancelExecution(t *testing.T) {
+	deps := testDeps()
+	a := newAPI(deps)
+	mux := http.NewServeMux()
+	a.registerRoutes(mux)
+
+	// Create a fake execution in the store.
+	cancelled := false
+	exec := &execution{
+		id:     "exec-1",
+		cancel: func() { cancelled = true },
+		notify: make(chan struct{}, 1),
+	}
+	a.executions.mu.Lock()
+	a.executions.execs["exec-1"] = exec
+	a.executions.mu.Unlock()
+
+	req := httptest.NewRequest("POST", "/api/executions/exec-1/cancel", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["status"] != "cancelled" {
+		t.Errorf("status = %q, want cancelled", resp["status"])
+	}
+	if !cancelled {
+		t.Error("cancel function was not called")
+	}
+}
+
+func TestCancelExecution_NotFound(t *testing.T) {
+	mux := setupTestAPI(t)
+	req := httptest.NewRequest("POST", "/api/executions/nonexistent/cancel", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestStreamExecution_NotFound(t *testing.T) {
+	mux := setupTestAPI(t)
+	req := httptest.NewRequest("GET", "/api/executions/nonexistent/stream", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestStreamExecution_CompletedExecution(t *testing.T) {
+	deps := testDeps()
+	a := newAPI(deps)
+	mux := http.NewServeMux()
+	a.registerRoutes(mux)
+
+	// Create a completed execution with some output lines.
+	exec := &execution{
+		id:      "exec-1",
+		lines:   []string{"line1", "line2"},
+		done:    true,
+		exitErr: nil,
+		cancel:  func() {},
+		notify:  make(chan struct{}, 1),
+	}
+	a.executions.mu.Lock()
+	a.executions.execs["exec-1"] = exec
+	a.executions.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/executions/exec-1/stream", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "data: line1") {
+		t.Error("expected line1 in SSE output")
+	}
+	if !strings.Contains(body, "data: line2") {
+		t.Error("expected line2 in SSE output")
+	}
+	if !strings.Contains(body, "event: done") {
+		t.Error("expected done event in SSE output")
+	}
+	if !strings.Contains(body, "data: success") {
+		t.Error("expected success status in done event")
+	}
+
+	ct := w.Header().Get("Content-Type")
+	if ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+}
+
+func TestStreamExecution_CompletedWithError(t *testing.T) {
+	deps := testDeps()
+	a := newAPI(deps)
+	mux := http.NewServeMux()
+	a.registerRoutes(mux)
+
+	exec := &execution{
+		id:      "exec-2",
+		lines:   []string{"some output"},
+		done:    true,
+		exitErr: fmt.Errorf("exit status 1"),
+		cancel:  func() {},
+		notify:  make(chan struct{}, 1),
+	}
+	a.executions.mu.Lock()
+	a.executions.execs["exec-2"] = exec
+	a.executions.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/executions/exec-2/stream", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "event: done") {
+		t.Error("expected done event")
+	}
+	if !strings.Contains(body, "error: exit status 1") {
+		t.Error("expected error status in done event")
+	}
+}
+
+// --- Theme Tests ---
+
 func TestGetTheme(t *testing.T) {
 	mux := setupTestAPI(t)
 	req := httptest.NewRequest("GET", "/api/theme", nil)
@@ -98,18 +549,199 @@ func TestGetTheme(t *testing.T) {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
 
-	var theme themeResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &theme); err != nil {
+	var resp themeResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 
-	if theme.Name != "github" {
-		t.Errorf("theme name = %q", theme.Name)
+	if resp.Name != "github" {
+		t.Errorf("theme name = %q", resp.Name)
 	}
-	if theme.Colors["primary"] != "#58a6ff" {
-		t.Errorf("primary = %q", theme.Colors["primary"])
+	if resp.Colors["primary"] != "#58a6ff" {
+		t.Errorf("primary = %q", resp.Colors["primary"])
 	}
 }
+
+func TestGetTheme_NilTheme(t *testing.T) {
+	deps := testDeps()
+	deps.Theme = nil
+	mux := setupTestAPIWithDeps(t, deps)
+
+	req := httptest.NewRequest("GET", "/api/theme", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp themeResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Name != "default" {
+		t.Errorf("theme name = %q, want default", resp.Name)
+	}
+}
+
+func TestListThemes(t *testing.T) {
+	mux := setupTestAPI(t)
+	req := httptest.NewRequest("GET", "/api/themes", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp["active"] != "github" {
+		t.Errorf("active = %v, want github", resp["active"])
+	}
+	themes, ok := resp["themes"].([]any)
+	if !ok {
+		t.Fatal("themes is not an array")
+	}
+	if len(themes) == 0 {
+		t.Error("expected at least one bundled theme")
+	}
+}
+
+func TestListThemes_NilTheme(t *testing.T) {
+	deps := testDeps()
+	deps.Theme = nil
+	mux := setupTestAPIWithDeps(t, deps)
+
+	req := httptest.NewRequest("GET", "/api/themes", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp["active"] != "" {
+		t.Errorf("active = %v, want empty string", resp["active"])
+	}
+}
+
+func TestSetTheme_BadRequest(t *testing.T) {
+	mux := setupTestAPI(t)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"invalid json", `not json`},
+		{"empty name", `{"name": ""}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("PUT", "/api/theme", strings.NewReader(tc.body))
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", w.Code)
+			}
+		})
+	}
+}
+
+func TestSetTheme_NotFound(t *testing.T) {
+	deps := testDeps()
+	deps.ThemeLoader = &mockThemeLoader{themes: map[string]*domain.ThemeFile{}}
+	mux := setupTestAPIWithDeps(t, deps)
+
+	body := strings.NewReader(`{"name": "nonexistent"}`)
+	req := httptest.NewRequest("PUT", "/api/theme", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestSetTheme_Success(t *testing.T) {
+	deps := testDeps()
+	deps.ThemeLoader = &mockThemeLoader{
+		themes: map[string]*domain.ThemeFile{
+			"tokyo-night": {
+				Name: "tokyo-night",
+				Defs: map[string]string{"bg": "#1a1b26"},
+				Theme: map[string]json.RawMessage{
+					"background": json.RawMessage(`{"dark":"bg","light":"bg"}`),
+				},
+			},
+		},
+	}
+	deps.ConfigStore = &mockConfigStore{saved: deps.Config}
+	mux := setupTestAPIWithDeps(t, deps)
+
+	body := strings.NewReader(`{"name": "tokyo-night"}`)
+	req := httptest.NewRequest("PUT", "/api/theme", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+
+	var resp themeResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Name != "tokyo-night" {
+		t.Errorf("name = %q, want tokyo-night", resp.Name)
+	}
+}
+
+func TestSetTheme_DemoModeSkipsSave(t *testing.T) {
+	deps := testDeps()
+	deps.Demo = true
+	store := &mockConfigStore{saved: deps.Config}
+	deps.ConfigStore = store
+	deps.ThemeLoader = &mockThemeLoader{
+		themes: map[string]*domain.ThemeFile{
+			"tokyo-night": {
+				Name: "tokyo-night",
+				Defs: map[string]string{"bg": "#1a1b26"},
+				Theme: map[string]json.RawMessage{
+					"background": json.RawMessage(`{"dark":"bg","light":"bg"}`),
+				},
+			},
+		},
+	}
+	mux := setupTestAPIWithDeps(t, deps)
+
+	body := strings.NewReader(`{"name": "tokyo-night"}`)
+	req := httptest.NewRequest("PUT", "/api/theme", body)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	// In demo mode, Save should not be called on the config store.
+	if store.saveCalls != 0 {
+		t.Errorf("Save called %d times in demo mode, want 0", store.saveCalls)
+	}
+}
+
+// --- Execution Store Tests ---
 
 func TestExecutionStoreEviction(t *testing.T) {
 	store := newExecutionStore()
@@ -197,5 +829,26 @@ func TestExecutionStoreEvictionKeepsRunning(t *testing.T) {
 	}
 	if completed != maxCompleted {
 		t.Errorf("completed count = %d, want %d", completed, maxCompleted)
+	}
+}
+
+func TestExecutionStoreGet(t *testing.T) {
+	store := newExecutionStore()
+
+	// Empty store returns not found.
+	if _, ok := store.get("exec-1"); ok {
+		t.Error("expected not found for empty store")
+	}
+
+	// Add an execution and retrieve it.
+	exec := &execution{id: "exec-1", notify: make(chan struct{}, 1)}
+	store.execs["exec-1"] = exec
+
+	got, ok := store.get("exec-1")
+	if !ok {
+		t.Fatal("expected to find exec-1")
+	}
+	if got.id != "exec-1" {
+		t.Errorf("id = %q", got.id)
 	}
 }


### PR DESCRIPTION
## Summary
- Raise test coverage from 51.6% → 80.1% across all packages
- Add Gremlins mutation testing config (`.gremlins.yaml`) with 91.8% efficacy
- 7,800+ lines of new/extended tests across 22 files

## Coverage highlights
| Package | Before | After |
|---|---|---|
| tui/help | 0% | 100% |
| config | 72.5% | 96.7% |
| vars | 79.5% | 92.3% |
| adapters | 72.5% | 87.5% |
| tui/output | 74.1% | 82.4% |
| vault | 64.9% | 75.4% |
| mcp | 67.6% | 76.9% |

## Mutation testing
Gremlins `unleash --diff main` results:
- **Efficacy**: 91.8% (target ≥70%)
- **Mutant coverage**: 79% (target ≥65%)
- Remaining LIVED: equivalent mutations in TUI layout arithmetic
- NOT_COVERED: `exec.Command("git")` calls and MCP server handlers (integration-test territory)

## Test plan
- [x] `go test ./...` — all green
- [x] `gremlins unleash --diff main` — passes thresholds