### PR TITLE
Refactor wizard persistence to message-based architecture

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"image/color"
 	"strings"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"dops/internal/tui/sidebar"
 	"dops/internal/tui/wizard"
 	"dops/internal/update"
+	"dops/internal/vars"
 
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
@@ -351,6 +353,20 @@ func (m App) handleAppMessage(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	case output.ExecutionDoneMsg:
 		m.output, _ = m.output.Update(msg)
 		return m, nil, true
+
+	case wizard.SaveFieldMsg:
+		var saveErr error
+		if m.deps.Config == nil || m.deps.Vault == nil {
+			saveErr = fmt.Errorf("persistence not configured")
+		} else {
+			keyPath := vars.VarKeyPath(msg.Scope, msg.ParamName, msg.CatalogName, msg.RunbookName)
+			if err := config.Set(m.deps.Config, keyPath, msg.Value); err != nil {
+				saveErr = err
+			} else if err := m.deps.Vault.Save(&m.deps.Config.Vars); err != nil {
+				saveErr = err
+			}
+		}
+		return m, func() tea.Msg { return wizard.SaveFieldResultMsg{Err: saveErr} }, true
 
 	case wizard.SubmitMsg:
 		m.state = stateNormal

--- a/internal/tui/app_extra_test.go
+++ b/internal/tui/app_extra_test.go
@@ -1376,6 +1376,42 @@ func TestFocusTargetFromMouse_OutputRegion(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// handleAppMessage: SaveFieldMsg
+// ---------------------------------------------------------------------------
+
+func TestHandleAppMessage_SaveFieldMsg(t *testing.T) {
+	m := NewApp(testCatalogs(), testutil.TestStyles())
+	m.Init()
+	m.state = stateWizard
+
+	msg := wizard.SaveFieldMsg{
+		Scope:       "global",
+		ParamName:   "region",
+		CatalogName: "default",
+		RunbookName: "hello-world",
+		Value:       "us-east-1",
+	}
+
+	result, cmd, handled := m.handleAppMessage(msg)
+	if !handled {
+		t.Error("SaveFieldMsg should be handled")
+	}
+	_ = result
+	if cmd == nil {
+		t.Fatal("should return a command with SaveFieldResultMsg")
+	}
+	// Execute the command — should return SaveFieldResultMsg.
+	// Without real config/vault, it will error, but the message type is correct.
+	resultMsg := cmd()
+	if saveResult, ok := resultMsg.(wizard.SaveFieldResultMsg); !ok {
+		t.Errorf("expected SaveFieldResultMsg, got %T", resultMsg)
+	} else if m.deps.Config == nil && saveResult.Err == nil {
+		// With nil config, should error.
+		t.Error("expected error with nil config")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/internal/tui/overlays.go
+++ b/internal/tui/overlays.go
@@ -41,9 +41,6 @@ func (m App) openWizard() (tea.Model, tea.Cmd) {
 		Resolved: resolved,
 	})
 	wiz.SetStyles(m.deps.Styles)
-	if m.deps.Config != nil {
-		wiz.SetStore(m.deps.Config, m.deps.Vault)
-	}
 	m.wizard = &wiz
 	m.state = stateWizard
 	return m, wiz.Init()

--- a/internal/tui/wizard/messages.go
+++ b/internal/tui/wizard/messages.go
@@ -9,3 +9,18 @@ type SubmitMsg struct {
 }
 
 type CancelMsg struct{}
+
+// SaveFieldMsg is emitted when the user confirms saving a parameter value.
+// The parent (App) handles the actual persistence via config.Set + vault.Save.
+type SaveFieldMsg struct {
+	Scope       string
+	ParamName   string
+	CatalogName string
+	RunbookName string
+	Value       string
+}
+
+// SaveFieldResultMsg is sent back to the wizard after a save attempt.
+type SaveFieldResultMsg struct {
+	Err error
+}

--- a/internal/tui/wizard/model.go
+++ b/internal/tui/wizard/model.go
@@ -5,10 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"dops/internal/config"
 	"dops/internal/domain"
 	"dops/internal/theme"
-	"dops/internal/vars"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
@@ -27,8 +25,9 @@ const (
 type wizardPhase int
 
 const (
-	phaseInput   wizardPhase = iota // collecting user input
-	phaseSave                       // asking "Save for future runs?"
+	phaseInput       wizardPhase = iota // collecting user input
+	phaseSave                           // asking "Save for future runs?"
+	phaseWaitingSave                    // waiting for App to confirm save
 )
 
 type Model struct {
@@ -49,8 +48,6 @@ type Model struct {
 	skipped  map[int]bool        // indices of auto-applied (skipped) fields
 	width    int
 	styles   *theme.Styles
-	cfg      *domain.Config      // config to save into
-	vault    domain.VaultStore    // encrypted parameter storage
 }
 
 // WizardConfig holds options for creating a wizard model.
@@ -140,13 +137,6 @@ func (m Model) SkippedCount() int {
 
 func (m *Model) SetStyles(s *theme.Styles) {
 	m.styles = s
-}
-
-// SetStore provides config persistence for the "Save for future runs?" feature.
-// Values are saved to the encrypted vault.
-func (m *Model) SetStore(cfg *domain.Config, vlt domain.VaultStore) {
-	m.cfg = cfg
-	m.vault = vlt
 }
 
 func (m *Model) initField(idx int) {
@@ -294,7 +284,17 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
+	case SaveFieldResultMsg:
+		if msg.Err != nil {
+			m.err = fmt.Sprintf("save failed: %v", msg.Err)
+		}
+		m.phase = phaseInput
+		return m.advance()
+
 	case tea.KeyPressMsg:
+		if m.phase == phaseWaitingSave {
+			return m, nil
+		}
 		if msg.Code == tea.KeyEscape {
 			return m, func() tea.Msg { return CancelMsg{} }
 		}
@@ -488,13 +488,12 @@ func (m Model) updateSaveConfirm(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	case msg.Code == tea.KeyRight || msg.Text == "l":
 		m.cursor = 1 // No
 	case msg.Text == "y" || msg.Text == "Y":
-		m.saveCurrentField()
-		return m.advance()
+		return m.emitSave()
 	case msg.Text == "n" || msg.Text == "N":
 		return m.advance()
 	case msg.Code == tea.KeyEnter:
 		if m.cursor == 0 {
-			m.saveCurrentField()
+			return m.emitSave()
 		}
 		return m.advance()
 	}
@@ -516,22 +515,17 @@ func (m Model) advanceOrSave() (Model, tea.Cmd) {
 	return m.advance()
 }
 
-func (m *Model) saveCurrentField() {
-	if m.vault == nil || m.cfg == nil {
-		return
-	}
+func (m Model) emitSave() (Model, tea.Cmd) {
 	p := m.params[m.current]
-	val := m.values[p.Name]
-
-	// Set the value in the in-memory config (vault stores plaintext — no per-value encryption).
-	keyPath := vars.VarKeyPath(p.Scope, p.Name, m.catalog.Name, m.runbook.Name)
-
-	if err := config.Set(m.cfg, keyPath, val); err != nil {
-		m.err = fmt.Sprintf("save failed: %v", err)
-		return
-	}
-	if err := m.vault.Save(&m.cfg.Vars); err != nil {
-		m.err = fmt.Sprintf("save failed: %v", err)
+	m.phase = phaseWaitingSave
+	return m, func() tea.Msg {
+		return SaveFieldMsg{
+			Scope:       p.Scope,
+			ParamName:   p.Name,
+			CatalogName: m.catalog.Name,
+			RunbookName: m.runbook.Name,
+			Value:       m.values[p.Name],
+		}
 	}
 }
 

--- a/internal/tui/wizard/model_extra_test.go
+++ b/internal/tui/wizard/model_extra_test.go
@@ -2,6 +2,7 @@ package wizard
 
 import (
 	"dops/internal/domain"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1498,5 +1499,185 @@ func TestSecretField_EmptyInputKeepsSaved(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Fatal("should submit after accepting saved secret")
+	}
+}
+
+// ---------- SaveFieldMsg / SaveFieldResultMsg flow ----------
+
+func TestSaveConfirm_Yes_EmitsSaveFieldMsg(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.save",
+		Name:       "save",
+		Parameters: []domain.Parameter{stringParam("region", true, "global")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("us-east-1")
+
+	// Press enter → triggers advanceOrSave (value changed, global scope → save prompt).
+	m, _ = m.Update(enterMsg())
+	if m.phase != phaseSave {
+		t.Fatalf("expected phaseSave, got %d", m.phase)
+	}
+
+	// Press 'y' to confirm save.
+	m, cmd := m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	if m.phase != phaseWaitingSave {
+		t.Fatalf("expected phaseWaitingSave, got %d", m.phase)
+	}
+	if cmd == nil {
+		t.Fatal("should emit a command")
+	}
+
+	// Execute the command to get the message.
+	msg := cmd()
+	saveMsg, ok := msg.(SaveFieldMsg)
+	if !ok {
+		t.Fatalf("expected SaveFieldMsg, got %T", msg)
+	}
+	if saveMsg.Scope != "global" {
+		t.Errorf("scope = %q, want global", saveMsg.Scope)
+	}
+	if saveMsg.ParamName != "region" {
+		t.Errorf("param = %q, want region", saveMsg.ParamName)
+	}
+	if saveMsg.Value != "us-east-1" {
+		t.Errorf("value = %q, want us-east-1", saveMsg.Value)
+	}
+}
+
+func TestSaveConfirm_No_SkipsSave(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.save",
+		Name:       "save",
+		Parameters: []domain.Parameter{stringParam("region", true, "global")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("us-east-1")
+
+	m, _ = m.Update(enterMsg())
+	// Press 'n' to decline save → should advance and emit SubmitMsg.
+	m, cmd := m.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	if m.phase == phaseWaitingSave {
+		t.Error("should not enter phaseWaitingSave on decline")
+	}
+	if cmd == nil {
+		t.Fatal("should emit SubmitMsg command")
+	}
+	msg := cmd()
+	if _, ok := msg.(SubmitMsg); !ok {
+		t.Errorf("expected SubmitMsg, got %T", msg)
+	}
+}
+
+func TestSaveFieldResultMsg_Success_Advances(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.save",
+		Name:       "save",
+		Parameters: []domain.Parameter{stringParam("region", true, "global")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("us-east-1")
+
+	m, _ = m.Update(enterMsg())
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	if m.phase != phaseWaitingSave {
+		t.Fatalf("expected phaseWaitingSave, got %d", m.phase)
+	}
+
+	// Simulate successful save result.
+	m, cmd := m.Update(SaveFieldResultMsg{Err: nil})
+	if m.phase != phaseInput {
+		t.Errorf("expected phaseInput after result, got %d", m.phase)
+	}
+	if m.err != "" {
+		t.Errorf("unexpected error: %s", m.err)
+	}
+	if cmd == nil {
+		t.Fatal("should emit SubmitMsg after advancing")
+	}
+}
+
+func TestSaveFieldResultMsg_Error_SetsErr(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.save",
+		Name:       "save",
+		Parameters: []domain.Parameter{stringParam("region", true, "global")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("us-east-1")
+
+	m, _ = m.Update(enterMsg())
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+
+	// Simulate failed save.
+	m, _ = m.Update(SaveFieldResultMsg{Err: fmt.Errorf("disk full")})
+	if !strings.Contains(m.err, "disk full") {
+		t.Errorf("expected error containing 'disk full', got %q", m.err)
+	}
+}
+
+func TestSaveConfirm_LocalScope_NoSavePrompt(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.local",
+		Name:       "local",
+		Parameters: []domain.Parameter{localStringParam("tmp", true)},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("value")
+
+	// Enter should advance directly (no save prompt for local scope).
+	m, cmd := m.Update(enterMsg())
+	if m.phase == phaseSave {
+		t.Error("local scope should skip save prompt")
+	}
+	if cmd == nil {
+		t.Fatal("should emit SubmitMsg")
+	}
+}
+
+func TestSaveConfirm_EnterWithCursorYes_EmitsSave(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.save",
+		Name:       "save",
+		Parameters: []domain.Parameter{stringParam("region", true, "global")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("us-east-1")
+
+	m, _ = m.Update(enterMsg())
+	// Move cursor to Yes (left).
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	// Press Enter with cursor on Yes.
+	m, cmd := m.Update(enterMsg())
+	if m.phase != phaseWaitingSave {
+		t.Fatalf("expected phaseWaitingSave, got %d", m.phase)
+	}
+	if cmd == nil {
+		t.Fatal("should emit save command")
+	}
+}
+
+func TestPhaseWaitingSave_IgnoresKeypresses(t *testing.T) {
+	rb := domain.Runbook{
+		ID:         "test.save",
+		Name:       "save",
+		Parameters: []domain.Parameter{stringParam("region", true, "global")},
+	}
+	m := New(WizardConfig{Runbook: rb, Catalog: defaultCatalog()})
+	m.input.SetValue("us-east-1")
+
+	m, _ = m.Update(enterMsg())
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	if m.phase != phaseWaitingSave {
+		t.Fatalf("expected phaseWaitingSave, got %d", m.phase)
+	}
+
+	// Keys should be ignored during wait.
+	m, cmd := m.Update(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	if cmd != nil {
+		t.Error("keypresses should be ignored during phaseWaitingSave")
+	}
+	if m.phase != phaseWaitingSave {
+		t.Error("phase should remain phaseWaitingSave")
 	}
 }


### PR DESCRIPTION
## Summary

- **Removes** `config` and `vault` dependencies from the wizard package entirely
- **Replaces** direct `saveCurrentField()` calls with `SaveFieldMsg` / `SaveFieldResultMsg` message round-trip
- **Adds** `phaseWaitingSave` to block keypresses during the save round-trip
- **Moves** persistence logic (`config.Set` + `vault.Save`) to the App handler where it belongs

This follows BubbleTea's Elm architecture: child components emit messages, the parent handles side effects. The wizard package no longer imports `config`, `vault`, or `vars`.

Supersedes #43 (rebased on main after app decomposition landed).

## Test plan

- [x] 7 new wizard tests: save confirm yes/no, result success/error, local scope skip, enter-key confirm, keypress blocking during wait
- [x] 1 new app handler test: `TestHandleAppMessage_SaveFieldMsg`
- [x] Full test suite passes (`go test ./...`)
- [x] Wizard package has zero imports from `config`, `vault`, or `vars`