### PR TITLE
Add nosec annotations for code scanning false positives

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -180,7 +180,7 @@ func cloneRepo(url, targetDir, ref string) error {
 		}
 		cloneArgs = []string{"clone", "--branch", ref, url, targetDir}
 	}
-	gitCmd := exec.Command("git", cloneArgs...) // #nosec G204 -- url is a user-provided git remote
+	gitCmd := exec.Command("git", cloneArgs...) // #nosec G204,G702 -- url is a user-provided git remote, ref validated by isValidGitRef
 	gitCmd.Stdout = os.Stdout
 	gitCmd.Stderr = os.Stderr
 	if err := gitCmd.Run(); err != nil {
@@ -243,7 +243,7 @@ func newCatalogInstallCmd(dopsDir string) *cobra.Command {
 
 			// Validate sub-path stays within the cloned repository.
 			if subPath != "" {
-				validated, err := validateSubPath(targetDir, subPath)
+				validated, err := validateSubPath(targetDir, subPath) // #nosec G703 -- targetDir is tool-constructed, subPath validated below
 				if err != nil {
 					_ = os.RemoveAll(targetDir)
 					return err

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -78,7 +78,7 @@ func shouldSkip(v string) bool {
 // readCache reads the cached result if it's fresh enough.
 // Returns the CheckResult and true if the cache is valid.
 func readCache(path, current string) (CheckResult, bool) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is internal cache file (~/.dops/cache.json)
 	if err != nil {
 		return CheckResult{}, false
 	}


### PR DESCRIPTION
## Summary

Suppress 3 pre-existing gosec alerts that are false positives:

- **G702** `cmd/catalog.go:183` — `git clone` URL is user-provided by design, git ref validated by `isValidGitRef()`
- **G703** `cmd/catalog.go:248` — `targetDir` is tool-constructed path, `subPath` validated by `validateSubPath()`
- **G304** `internal/update/check.go:81` — Cache file path is internal (`~/.dops/cache.json`), not user input

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` passes (23 packages)