### PR TITLE
Add nosec annotation for RemoveAll path traversal alert

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -245,7 +245,7 @@ func newCatalogInstallCmd(dopsDir string) *cobra.Command {
 			if subPath != "" {
 				validated, err := validateSubPath(targetDir, subPath) // #nosec G703 -- targetDir is tool-constructed, subPath validated below
 				if err != nil {
-					_ = os.RemoveAll(targetDir)
+					_ = os.RemoveAll(targetDir) // #nosec G703 -- targetDir is sandboxed under ~/.dops/catalogs/
 					return err
 				}
 				subPath = validated


### PR DESCRIPTION
Suppress G703 false positive on `os.RemoveAll(targetDir)` in catalog install. The path is sandboxed under `~/.dops/catalogs/`, not arbitrary user input.