### PR TITLE
Fix gosec findings in internal/history

### DIFF
--- a/internal/history/archive.go
+++ b/internal/history/archive.go
@@ -24,7 +24,7 @@ type archiveEntry struct {
 // AppendToActiveArchive finds or creates the active .log.gz archive (< 10MB)
 // and appends the entry. Returns the archive path and entry name.
 func AppendToActiveArchive(logsDir, entryName string, content []byte) (archivePath string, err error) {
-	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+	if err := os.MkdirAll(logsDir, 0o750); err != nil {
 		return "", fmt.Errorf("create logs dir: %w", err)
 	}
 
@@ -189,7 +189,7 @@ func writeArchive(path string, entries []archiveEntry) error {
 		return err
 	}
 
-	return os.WriteFile(path, buf.Bytes(), 0o644)
+	return os.WriteFile(path, buf.Bytes(), 0o600)
 }
 
 func generateArchiveID() string {

--- a/internal/history/store.go
+++ b/internal/history/store.go
@@ -44,7 +44,7 @@ func NewFileStore(dir string, _ int64) *FileExecutionStore {
 
 // Record writes an execution record to disk.
 func (s *FileExecutionStore) Record(record *domain.ExecutionRecord) error {
-	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+	if err := os.MkdirAll(s.dir, 0o750); err != nil {
 		return fmt.Errorf("create history dir: %w", err)
 	}
 
@@ -55,7 +55,7 @@ func (s *FileExecutionStore) Record(record *domain.ExecutionRecord) error {
 
 	filename := s.filename(record)
 	path := filepath.Join(s.dir, filename)
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("write record: %w", err)
 	}
 
@@ -220,7 +220,9 @@ func (s *FileExecutionStore) listFiles() ([]string, error) {
 }
 
 func (s *FileExecutionStore) loadRecord(filename string) (*domain.ExecutionRecord, error) {
-	data, err := os.ReadFile(filepath.Join(s.dir, filename))
+	// filename comes from listRecordFilenames which reads s.dir via os.ReadDir
+	// and filters to *.json entries; strip any path component defensively.
+	data, err := os.ReadFile(filepath.Join(s.dir, filepath.Base(filename))) // #nosec G304 -- constrained to s.dir
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Resolves the 5 open gosec code-scanning alerts in `internal/history/` (all introduced by the v0.12.0 execution-history feature):

| # | Rule | Fix |
|---|------|-----|
| 89, 86 | G301 | `os.MkdirAll` perms 0755 → 0750 |
| 91, 90 | G306 | `os.WriteFile` perms 0644 → 0600 |
| 71 | G304 | `loadRecord` wraps filename in `filepath.Base` and annotates `#nosec G304`; input always comes from `os.ReadDir(s.dir)` filtered to `*.json` |

Execution history records may contain sensitive parameter values, so user-only perms are the right default.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/history/...`
- [ ] CI green